### PR TITLE
swift 2.2 / xcode 7.3 default switch

### DIFF
--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -351,6 +351,7 @@ public enum Device {
             case .TV:           self = .TV
             case .CarPlay:      self = .CarPlay
             case .Unspecified:  self = .Unspecified
+            default:            self = .Unspecified
             }
         }
 


### PR DESCRIPTION
Couldn't compile without a `default` in the switch statement. But I can see that the Travis build fails, so not sure if it's the right solution.