### PR TITLE
Fix type_name lint errors from preventing build

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ opt_in_rules:
 
 disabled_rules:
  - file_length
+ - type_name
 
 line_length:
  - 160


### PR DESCRIPTION
The swiftlint rule removed in the 0.3.4 release causes build errors. This re-adds the `type_name` to the disabled rule list.