### PR TITLE
[Swift 2.3] Fix crash for looking up sim id on real device

### DIFF
--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -7,10 +7,11 @@
 //
 
 import class UIKit.UIDevice
+import class Foundation.NSProcessInfo
 import struct Darwin.utsname
 import func Darwin.uname
 import func Darwin.round
-import func Darwin.getenv
+
 
 // MARK: - Device
 

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -240,13 +240,13 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(String(UTF8String: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
       default:                                        return UnknownDevice(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return AppleTV4
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(String(UTF8String: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
       default:                                        return UnknownDevice(identifier)
       }
     #endif

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -240,13 +240,17 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(
+                                                        NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"
+                                                      ))
       default:                                        return UnknownDevice(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return AppleTV4
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(
+                                                        NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"
+                                                      ))
       default:                                        return UnknownDevice(identifier)
       }
     #endif

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -240,15 +240,13 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      // swiftlint:disable:next force_unwrapping
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(String(UTF8String: getenv("SIMULATOR_MODEL_IDENTIFIER"))!))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(String(UTF8String: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
       default:                                        return UnknownDevice(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return AppleTV4
-      // swiftlint:disable:next force_unwrapping
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(String(UTF8String: getenv("SIMULATOR_MODEL_IDENTIFIER"))!))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(String(UTF8String: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
       default:                                        return UnknownDevice(identifier)
       }
     #endif

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -240,13 +240,13 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"))
       default:                                        return UnknownDevice(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return AppleTV4
-      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
+      case "i386", "x86_64":                          return Simulator(mapIdentifierToDevice(NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))
       default:                                        return UnknownDevice(identifier)
       }
     #endif


### PR DESCRIPTION
This fixes a crash when trying to lookup a simulator identifier on a real device.  Fixes Issue #60 