### PR TITLE
[Swift 3.0] Fix crash for looking up sim id on real device

### DIFF
--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -239,15 +239,13 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      // swiftlint:disable:next force_unwrapping
-      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: String(validatingUTF8: getenv("SIMULATOR_MODEL_IDENTIFIER"))!))
+      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: String(validatingUTF8: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
       default:                                        return unknown(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return appleTV4
-      // swiftlint:disable:next force_unwrapping
-      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: String(validatingUTF8: getenv("SIMULATOR_MODEL_IDENTIFIER"))!))
+      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: String(validatingUTF8: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
       default:                                        return unknown(identifier)
       }
     #endif

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -239,13 +239,13 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      case "i386", "x86_64":                          return Simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
+      case "i386", "x86_64":                          return Simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"))
       default:                                        return unknown(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return appleTV4
-      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
+      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))
       default:                                        return unknown(identifier)
       }
     #endif

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -240,7 +240,7 @@ public enum Device {
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
       case "i386", "x86_64":                          return simulator(mapToDevice(
-                                                        identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"
+                                                        identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"
                                                       ))
       default:                                        return unknown(identifier)
       }
@@ -248,7 +248,7 @@ public enum Device {
       switch identifier {
       case "AppleTV5,3":                              return appleTV4
       case "i386", "x86_64":                          return simulator(mapToDevice(
-                                                        identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"
+                                                        identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"
                                                       ))
       default:                                        return unknown(identifier)
       }

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -239,13 +239,17 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      case "i386", "x86_64":                          return Simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"))
+      case "i386", "x86_64":                          return simulator(mapToDevice(
+                                                        identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"
+                                                      ))
       default:                                        return unknown(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return appleTV4
-      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))
+      case "i386", "x86_64":                          return simulator(mapToDevice(
+                                                        identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"
+                                                      ))
       default:                                        return unknown(identifier)
       }
     #endif

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -239,13 +239,13 @@ public enum Device {
       case "iPad5,1", "iPad5,2":                      return iPadMini4
       case "iPad6,3", "iPad6,4":                      return iPadPro9Inch
       case "iPad6,7", "iPad6,8":                      return iPadPro12Inch
-      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: String(validatingUTF8: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
+      case "i386", "x86_64":                          return Simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
       default:                                        return unknown(identifier)
       }
     #elseif os(tvOS)
       switch identifier {
       case "AppleTV5,3":                              return appleTV4
-      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: String(validatingUTF8: getenv("SIMULATOR_MODEL_IDENTIFIER")) ?? identifier))
+      case "i386", "x86_64":                          return simulator(mapToDevice(identifier: NSProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "Unknown"))
       default:                                        return unknown(identifier)
       }
     #endif


### PR DESCRIPTION
This fixes a crash when trying to lookup a simulator identifier on a real device. Fixes Issue #60