### PR TITLE
[DiskSpace] Move iOS availability macros to specific methods, not extension

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -565,7 +565,7 @@ public enum Device {
   /// True when a Guided Access session is currently active; otherwise, false.
   public var isGuidedAccessSessionActive: Bool {
     #if os(iOS)
-    return UIAccessibility.isGuidedAccessEnabled
+    return UIAccessibilityIsGuidedAccessEnabled()
     #else
     return false
     #endif
@@ -785,7 +785,6 @@ extension Device {
 
 #if os(iOS)
 // MARK: - DiskSpace
-@available(iOS 11.0, *)
 extension Device {
 
   /// Return the root url
@@ -816,6 +815,7 @@ extension Device {
   }
 
   /// The volume’s available capacity in bytes for storing important resources.
+  @available(iOS 11.0, *)
   public static var volumeAvailableCapacityForImportantUsage: Int64? {
     do {
       let values = try rootURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
@@ -826,6 +826,7 @@ extension Device {
   }
 
   /// The volume’s available capacity in bytes for storing nonessential resources.
+  @available(iOS 11.0, *)
   public static var volumeAvailableCapacityForOpportunisticUsage: Int64? { //swiftlint:disable:this identifier_name
     do {
       let values = try rootURL.resourceValues(forKeys: [.volumeAvailableCapacityForOpportunisticUsageKey])
@@ -836,6 +837,7 @@ extension Device {
   }
 
   /// All volumes capacity information in bytes.
+  @available(iOS 11.0, *)
   public static var volumes: [URLResourceKey: Int64]? {
     do {
       let values = try rootURL.resourceValues(forKeys: [

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -578,7 +578,6 @@ extension Device {
 
 #if os(iOS)
 // MARK: - DiskSpace
-@available(iOS 11.0, *)
 extension Device {
 
   /// Return the root url
@@ -609,6 +608,7 @@ extension Device {
   }
 
   /// The volume’s available capacity in bytes for storing important resources.
+  @available(iOS 11.0, *)
   public static var volumeAvailableCapacityForImportantUsage: Int64? {
     do {
       let values = try rootURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
@@ -619,6 +619,7 @@ extension Device {
   }
 
   /// The volume’s available capacity in bytes for storing nonessential resources.
+  @available(iOS 11.0, *)
   public static var volumeAvailableCapacityForOpportunisticUsage: Int64? { //swiftlint:disable:this identifier_name
     do {
       let values = try rootURL.resourceValues(forKeys: [.volumeAvailableCapacityForOpportunisticUsageKey])
@@ -629,6 +630,7 @@ extension Device {
   }
 
   /// All volumes capacity information in bytes.
+  @available(iOS 11.0, *)
   public static var volumes: [URLResourceKey: Int64]? {
     do {
       let values = try rootURL.resourceValues(forKeys: [


### PR DESCRIPTION
I've updated the extension about DiskSpace.

The `@available(iOS 11.0, *)` was misplaced on the extension, not on specific methods.

This will open `volumeTotalCapacity` & `volumeAvailableCapacity` for iOS < 11 🙂 