### PR TITLE
Create allDevicesWithRoundedDisplayCorners and hasRoundedDisplayCorners variables.

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -623,11 +623,6 @@ public enum Device {
     public static var allFaceIDCapableDevices: [Device] {
       return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr, .iPadPro11Inch, .iPadPro12Inch3]
     }
-  
-    /// All devices that feature a sensor housing in the screen
-    public static var allDevicesWithASensorHousing: [Device] {
-      return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr]
-    }
 
     /// Returns whether or not the device has Touch ID
     public var isTouchIDCapable: Bool {
@@ -638,15 +633,20 @@ public enum Device {
     public var isFaceIDCapable: Bool {
       return isOneOf(Device.allFaceIDCapableDevices)
     }
-  
-    /// Returns whether or not the device has a sensor housing
-    public var hasSensorHousing: Bool {
-      return isOneOf(Device.allDevicesWithASensorHousing)
-    }
 
     /// Returns whether or not the device has any biometric sensor (i.e. Touch ID or Face ID)
     public var hasBiometricSensor: Bool {
       return isTouchIDCapable || isFaceIDCapable
+    }
+  
+    /// All devices that feature a sensor housing in the screen
+    public static var allDevicesWithASensorHousing: [Device] {
+      return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr]
+    }
+  
+    /// Returns whether or not the device has a sensor housing
+    public var hasSensorHousing: Bool {
+      return isOneOf(Device.allDevicesWithASensorHousing)
     }
 
   #elseif os(tvOS)

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -623,6 +623,11 @@ public enum Device {
     public static var allFaceIDCapableDevices: [Device] {
       return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr, .iPadPro11Inch, .iPadPro12Inch3]
     }
+  
+    /// All devices that feature a sensor housing in the screen
+    public static var allDevicesWithASensorHousing: [Device] {
+      return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr]
+    }
 
     /// Returns whether or not the device has Touch ID
     public var isTouchIDCapable: Bool {
@@ -632,6 +637,11 @@ public enum Device {
     /// Returns whether or not the device has Face ID
     public var isFaceIDCapable: Bool {
       return isOneOf(Device.allFaceIDCapableDevices)
+    }
+  
+    /// Returns whether or not the device has a sensor housing
+    public var hasSensorHousing: Bool {
+      return isOneOf(Device.allDevicesWithASensorHousing)
     }
 
     /// Returns whether or not the device has any biometric sensor (i.e. Touch ID or Face ID)

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -640,13 +640,13 @@ public enum Device {
     }
   
     /// All devices that feature a sensor housing in the screen
-    public static var allDevicesWithASensorHousing: [Device] {
+    public static var allDevicesWithSensorHousing: [Device] {
       return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr]
     }
   
     /// Returns whether or not the device has a sensor housing
     public var hasSensorHousing: Bool {
-      return isOneOf(Device.allDevicesWithASensorHousing)
+      return isOneOf(Device.allDevicesWithSensorHousing)
     }
 
   #elseif os(tvOS)

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -648,6 +648,16 @@ public enum Device {
     public var hasSensorHousing: Bool {
       return isOneOf(Device.allDevicesWithSensorHousing)
     }
+  
+    /// All devices that feature a screen with rounded corners.
+    public static var allDevicesWithRoundedDisplayCorners: [Device] {
+      return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr, .iPadPro11Inch, .iPadPro12Inch3]
+    }
+  
+    /// Returns whether or not the device has a screen with rounded corners.
+    public var hasRoundedDisplayCorners: Bool {
+      return isOneOf(Device.allDevicesWithRoundedDisplayCorners)
+    }
 
   #elseif os(tvOS)
     /// All TVs


### PR DESCRIPTION
Create allDevicesWithRoundedDisplayCorners and hasRoundedDisplayCorners variables like suggested in https://github.com/dennisweissmann/DeviceKit/issues/159. Doesn't however implement the breaking changes that were also suggested there so the issue shouldn't be closed.

Would like to also implement a variable for getting the actual corner radius of the display but according to this StackOverflow answer, it isn't as simple as just setting `layer.cornerRadius`: https://apple.stackexchange.com/a/336499/277581

*(Additional commits are because I screwed up syncing my fork's master with upstream)*