### PR TITLE
Add application to be able to run Unit Tests on a real device

### DIFF
--- a/DeviceKit.xcodeproj/project.pbxproj
+++ b/DeviceKit.xcodeproj/project.pbxproj
@@ -24,6 +24,13 @@
 		6D29C0C01F122C7A005B52BD /* Device.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D29C0BF1F122C77005B52BD /* Device.generated.swift */; };
 		955EE5A31D5E581B008C3DA8 /* DeviceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 955EE59A1D5E581B008C3DA8 /* DeviceKit.framework */; };
 		955EE5B41D5E5A90008C3DA8 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C7E8451C61253900B0189E /* Tests.swift */; };
+		FC5F919622A5764E007FFC64 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5F919522A5764E007FFC64 /* AppDelegate.swift */; };
+		FC5F919822A5764E007FFC64 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5F919722A5764E007FFC64 /* ViewController.swift */; };
+		FC5F919B22A5764E007FFC64 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FC5F919922A5764E007FFC64 /* Main.storyboard */; };
+		FC5F919D22A57651007FFC64 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FC5F919C22A57651007FFC64 /* Assets.xcassets */; };
+		FC5F91A022A57651007FFC64 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FC5F919E22A57651007FFC64 /* LaunchScreen.storyboard */; };
+		FC5F91AE22A578BF007FFC64 /* DeviceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 955EE59A1D5E581B008C3DA8 /* DeviceKit.framework */; };
+		FC5F91AF22A578BF007FFC64 /* DeviceKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 955EE59A1D5E581B008C3DA8 /* DeviceKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,7 +41,35 @@
 			remoteGlobalIDString = 955EE5991D5E581B008C3DA8;
 			remoteInfo = DeviceKit;
 		};
+		FC5F91A522A576C0007FFC64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 95CBDB641BFD2B440065FC66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FC5F919222A5764E007FFC64;
+			remoteInfo = TestsApplication;
+		};
+		FC5F91B022A578BF007FFC64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 95CBDB641BFD2B440065FC66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 955EE5991D5E581B008C3DA8;
+			remoteInfo = DeviceKit;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		FC5F91B222A578BF007FFC64 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				FC5F91AF22A578BF007FFC64 /* DeviceKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		6D29C0BC1F122863005B52BD /* Device.swift.gyb */ = {isa = PBXFileReference; explicitFileType = text.script.python; fileEncoding = 4; lineEnding = 0; name = Device.swift.gyb; path = Source/Device.swift.gyb; sourceTree = "<group>"; };
@@ -56,6 +91,13 @@
 		95C7E8471C612ABA00B0189E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = "<group>"; };
 		95C7E84D1C6130DB00B0189E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		95C7E84E1C61332300B0189E /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		FC5F919322A5764E007FFC64 /* TestsApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestsApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC5F919522A5764E007FFC64 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		FC5F919722A5764E007FFC64 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		FC5F919A22A5764E007FFC64 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		FC5F919C22A57651007FFC64 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		FC5F919F22A57651007FFC64 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		FC5F91A122A57651007FFC64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +113,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				955EE5A31D5E581B008C3DA8 /* DeviceKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC5F919022A5764E007FFC64 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC5F91AE22A578BF007FFC64 /* DeviceKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,6 +168,7 @@
 			children = (
 				95C7E83B1C6122BF00B0189E /* Source */,
 				95C7E8411C61241200B0189E /* Tests */,
+				FC5F919422A5764E007FFC64 /* TestsApplication */,
 				954977F91E748DB000D6FAEB /* Scripts */,
 				957D18251C28C1E90067D203 /* README.md */,
 				95C7E84E1C61332300B0189E /* Package.swift */,
@@ -130,6 +181,7 @@
 				95C7E83F1C61239D00B0189E /* .gitignore */,
 				6D9B30FB1F1A2DC50008F7E0 /* Utils */,
 				95CBDB701BFD2B5F0065FC66 /* Products */,
+				FC5F91A722A5785D007FFC64 /* Frameworks */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -141,8 +193,29 @@
 			children = (
 				955EE59A1D5E581B008C3DA8 /* DeviceKit.framework */,
 				955EE5A21D5E581B008C3DA8 /* DeviceKitTests.xctest */,
+				FC5F919322A5764E007FFC64 /* TestsApplication.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		FC5F919422A5764E007FFC64 /* TestsApplication */ = {
+			isa = PBXGroup;
+			children = (
+				FC5F919522A5764E007FFC64 /* AppDelegate.swift */,
+				FC5F919722A5764E007FFC64 /* ViewController.swift */,
+				FC5F919922A5764E007FFC64 /* Main.storyboard */,
+				FC5F919C22A57651007FFC64 /* Assets.xcassets */,
+				FC5F919E22A57651007FFC64 /* LaunchScreen.storyboard */,
+				FC5F91A122A57651007FFC64 /* Info.plist */,
+			);
+			path = TestsApplication;
+			sourceTree = "<group>";
+		};
+		FC5F91A722A5785D007FFC64 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -189,11 +262,31 @@
 			);
 			dependencies = (
 				955EE5A51D5E581B008C3DA8 /* PBXTargetDependency */,
+				FC5F91A622A576C0007FFC64 /* PBXTargetDependency */,
 			);
 			name = DeviceKitTests;
 			productName = DeviceKitTests;
 			productReference = 955EE5A21D5E581B008C3DA8 /* DeviceKitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		FC5F919222A5764E007FFC64 /* TestsApplication */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC5F91A222A57651007FFC64 /* Build configuration list for PBXNativeTarget "TestsApplication" */;
+			buildPhases = (
+				FC5F918F22A5764E007FFC64 /* Sources */,
+				FC5F919022A5764E007FFC64 /* Frameworks */,
+				FC5F919122A5764E007FFC64 /* Resources */,
+				FC5F91B222A578BF007FFC64 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FC5F91B122A578BF007FFC64 /* PBXTargetDependency */,
+			);
+			name = TestsApplication;
+			productName = TestsApplication;
+			productReference = FC5F919322A5764E007FFC64 /* TestsApplication.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -201,7 +294,7 @@
 		95CBDB641BFD2B440065FC66 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0800;
+				LastSwiftUpdateCheck = 1020;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Dennis Weissmann";
 				TargetAttributes = {
@@ -217,6 +310,10 @@
 						CreatedOnToolsVersion = 8.0;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
+						TestTargetID = FC5F919222A5764E007FFC64;
+					};
+					FC5F919222A5764E007FFC64 = {
+						CreatedOnToolsVersion = 10.2.1;
 					};
 				};
 			};
@@ -227,6 +324,7 @@
 			knownRegions = (
 				English,
 				en,
+				Base,
 			);
 			mainGroup = 95CBDB631BFD2B440065FC66;
 			productRefGroup = 95CBDB701BFD2B5F0065FC66 /* Products */;
@@ -236,6 +334,7 @@
 				955EE5991D5E581B008C3DA8 /* DeviceKit */,
 				955EE5A11D5E581B008C3DA8 /* DeviceKitTests */,
 				6D7666191F1A083200F59630 /* Run SwiftLint */,
+				FC5F919222A5764E007FFC64 /* TestsApplication */,
 			);
 		};
 /* End PBXProject section */
@@ -252,6 +351,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC5F919122A5764E007FFC64 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC5F91A022A57651007FFC64 /* LaunchScreen.storyboard in Resources */,
+				FC5F919D22A57651007FFC64 /* Assets.xcassets in Resources */,
+				FC5F919B22A5764E007FFC64 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,6 +416,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FC5F918F22A5764E007FFC64 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC5F919822A5764E007FFC64 /* ViewController.swift in Sources */,
+				FC5F919622A5764E007FFC64 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -315,7 +433,36 @@
 			target = 955EE5991D5E581B008C3DA8 /* DeviceKit */;
 			targetProxy = 955EE5A41D5E581B008C3DA8 /* PBXContainerItemProxy */;
 		};
+		FC5F91A622A576C0007FFC64 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FC5F919222A5764E007FFC64 /* TestsApplication */;
+			targetProxy = FC5F91A522A576C0007FFC64 /* PBXContainerItemProxy */;
+		};
+		FC5F91B122A578BF007FFC64 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 955EE5991D5E581B008C3DA8 /* DeviceKit */;
+			targetProxy = FC5F91B022A578BF007FFC64 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		FC5F919922A5764E007FFC64 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FC5F919A22A5764E007FFC64 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		FC5F919E22A57651007FFC64 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FC5F919F22A57651007FFC64 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		6D76661B1F1A083300F59630 /* Debug */ = {
@@ -350,13 +497,13 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3M5P376P9C;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -410,13 +557,13 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3M5P376P9C;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -453,6 +600,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -463,10 +611,11 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = SWR98KT795;
+				DEVELOPMENT_TEAM = 3M5P376P9C;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -491,6 +640,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestsApplication.app/TestsApplication";
 			};
 			name = Debug;
 		};
@@ -499,6 +649,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -509,10 +660,11 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = SWR98KT795;
+				DEVELOPMENT_TEAM = 3M5P376P9C;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -532,6 +684,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestsApplication.app/TestsApplication";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -620,6 +773,98 @@
 			};
 			name = Release;
 		};
+		FC5F91A322A57651007FFC64 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 3M5P376P9C;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = TestsApplication/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit.TestsApplication;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FC5F91A422A57651007FFC64 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 3M5P376P9C;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = TestsApplication/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit.TestsApplication;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -655,6 +900,15 @@
 			buildConfigurations = (
 				95CBDB681BFD2B440065FC66 /* Debug */,
 				95CBDB691BFD2B440065FC66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC5F91A222A57651007FFC64 /* Build configuration list for PBXNativeTarget "TestsApplication" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC5F91A322A57651007FFC64 /* Debug */,
+				FC5F91A422A57651007FFC64 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -17,11 +17,17 @@ class DeviceKitTests: XCTestCase {
   let device = Device.current
 
   func testDeviceSimulator() {
-    XCTAssertTrue(device.isOneOf(Device.allSimulators))
+    if Device.current.isSimulator {
+      XCTAssertTrue(device.isOneOf(Device.allSimulators))
+    } else {
+      XCTAssertFalse(device.isOneOf(Device.allSimulators))
+    }
   }
 
   func testDeviceDescription() {
-    XCTAssertTrue(device.description.hasPrefix("Simulator"))
+    if Device.current.isSimulator {
+      XCTAssertTrue(device.description.hasPrefix("Simulator"))
+    }
     XCTAssertTrue(device.description.contains("iPhone")
       || device.description.contains("iPad")
       || device.description.contains("iPod")
@@ -31,7 +37,11 @@ class DeviceKitTests: XCTestCase {
   // MARK: - iOS
   #if os(iOS)
   func testIsSimulator() {
+    #if targetEnvironment(simulator)
     XCTAssertTrue(device.isSimulator)
+    #else
+    XCTAssertFalse(device.isSimulator)
+    #endif
   }
 
   func testIsPhoneIsPad() {

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -17,7 +17,7 @@ class DeviceKitTests: XCTestCase {
   let device = Device.current
 
   func testDeviceSimulator() {
-    if Device.current.isSimulator {
+    if device.isSimulator {
       XCTAssertTrue(device.isOneOf(Device.allSimulators))
     } else {
       XCTAssertFalse(device.isOneOf(Device.allSimulators))
@@ -25,7 +25,7 @@ class DeviceKitTests: XCTestCase {
   }
 
   func testDeviceDescription() {
-    if Device.current.isSimulator {
+    if device.isSimulator {
       XCTAssertTrue(device.description.hasPrefix("Simulator"))
     }
     XCTAssertTrue(device.description.contains("iPhone")

--- a/TestsApplication/AppDelegate.swift
+++ b/TestsApplication/AppDelegate.swift
@@ -1,0 +1,20 @@
+//
+//  AppDelegate.swift
+//  TestsApplication
+//
+//  Created by Zandor Smith on 03/06/2019.
+//  Copyright © 2019 Dennis Weissmann. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  var window: UIWindow?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    return true
+  }
+
+}

--- a/TestsApplication/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TestsApplication/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/TestsApplication/Assets.xcassets/Contents.json
+++ b/TestsApplication/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/TestsApplication/Base.lproj/LaunchScreen.storyboard
+++ b/TestsApplication/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/TestsApplication/Base.lproj/Main.storyboard
+++ b/TestsApplication/Base.lproj/Main.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="TestsApplication" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unit Testing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dzW-h2-Bqd">
+                                <rect key="frame" x="161" y="437.5" width="92" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="dzW-h2-Bqd" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="NDz-NI-PYM"/>
+                            <constraint firstItem="dzW-h2-Bqd" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="dVr-5T-ES3"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/TestsApplication/Info.plist
+++ b/TestsApplication/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/TestsApplication/ViewController.swift
+++ b/TestsApplication/ViewController.swift
@@ -1,0 +1,17 @@
+//
+//  ViewController.swift
+//  TestsApplication
+//
+//  Created by Zandor Smith on 03/06/2019.
+//  Copyright © 2019 Dennis Weissmann. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+
+}


### PR DESCRIPTION
This PR will add a `TestsApplication` target that is just an empty application. This application will be used to be able to run the existing Unit Tests on a real device. Now Unit Tests can be run for iPod touch since Xcode currently doesn't have any iPod touch simulators.