### PR TITLE
Add macos support #184

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
     platforms: [
         .iOS(.v8),
         .tvOS(.v9),
-        .watchOS(.v2)
+        .watchOS(.v2),
+        .macOS(.v10_14)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -319,7 +319,7 @@ public enum Device {
     case iMacRetina5K27Inch2019
     /// Device is a [iMac (Retina 4K, 21.5-inch, 2019)](https://support.apple.com/kb/SP789)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg)
     case iMacRetina4K215Inch2019
     /// Device is a [iMac (Retina 5K, 27-inch, 2017)](https://support.apple.com/kb/SP760)
     ///
@@ -327,11 +327,11 @@ public enum Device {
     case iMacRetina5K27Inch2017
     /// Device is a [iMac (Retina 4K, 21.5-inch, 2017)](https://support.apple.com/kb/SP759)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg)
     case iMacRetina4K215Inch2017
     /// Device is a [iMac (21.5-inch, 2017)](https://support.apple.com/kb/SP758)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg)
     case iMac215Inch2017
     /// Device is a [iMac (Retina 5K, 27-inch, Late 2015)](https://support.apple.com/kb/SP731)
     ///
@@ -339,11 +339,11 @@ public enum Device {
     case iMacRetina5K27InchLate2015
     /// Device is a [iMac (Retina 4K, 21.5-inch, Late 2015)](https://support.apple.com/kb/SP732)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2015.jpg)
     case iMacRetina4K215InchLate2015
     /// Device is a [iMac (21.5-inch, Late 2015)](https://support.apple.com/kb/SP733)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2015.jpg)
     case iMac215InchLate2015
     /// Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718) or [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)
     ///
@@ -423,7 +423,7 @@ public enum Device {
     case macBookAir13InchEarly2015
     /// Device is a [MacBook Air (11-inch, Early 2015)](https://support.apple.com/kb/SP713)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-11in-device.jpg)
     case macBookAir11InchEarly2015
     /// Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700) or [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)
     ///
@@ -431,7 +431,7 @@ public enum Device {
     case macBookAir13InchEarly2014
     /// Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699) or [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-11in-device.jpg)
     case macBookAir11InchEarly2014
     /// Device is a [MacBook Air (13-inch, Mid 2012)](https://support.apple.com/kb/SP670)
     ///
@@ -439,7 +439,7 @@ public enum Device {
     case macBookAir13InchMid2012
     /// Device is a [MacBook Air (11-inch, Mid 2012)](https://support.apple.com/kb/SP650)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-11in-device.jpg)
     case macBookAir11InchMid2012
     /// Device is a [MacBook Air (13-inch, Mid 2011)](https://support.apple.com/kb/SP683)
     ///
@@ -447,7 +447,7 @@ public enum Device {
     case macBookAir13InchMid2011
     /// Device is a [MacBook Air (11-inch, Mid 2011)](https://support.apple.com/kb/SP631)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-13in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-11in-device.jpg)
     case macBookAir11InchMid2011
     /// Device is a [MacBook Air (13-inch, Late 2010)](https://support.apple.com/kb/SP618)
     ///
@@ -455,7 +455,7 @@ public enum Device {
     case macBookAir13InchLate2010
     /// Device is a [MacBook Air (11-inch, Late 2010)](https://support.apple.com/kb/SP617)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2010-11in-device.jpg)
     case macBookAir11InchLate2010
     /// Device is a [MacBook Air (Mid 2009)](https://support.apple.com/kb/SP548)
     ///
@@ -471,7 +471,7 @@ public enum Device {
     case macBookPro13Inch2019TwoThunderbolt3Ports
     /// Device is a [MacBook Pro (15-inch, 2019)](https://support.apple.com/kb/SP794)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg)
     case macBookPro15Inch2019
     /// Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795) or [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)
     ///
@@ -487,11 +487,11 @@ public enum Device {
     case macBookPro15Inch2017
     /// Device is a [MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP755)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-13in-device.jpg)
     case macBookPro13Inch2017FourThunderbolt3Ports
     /// Device is a [MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP754)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-13in-device-2thunderbolt-3ports.jpg)
     case macBookPro13Inch2017TwoThunderbolt3Ports
     /// Device is a [MacBook Pro (15-inch, 2016)](https://support.apple.com/kb/SP749)
     ///
@@ -499,11 +499,11 @@ public enum Device {
     case macBookPro15Inch2016
     /// Device is a [MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP748)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-13in-device.jpg)
     case macBookPro13Inch2016FourThunderbolt3Ports
     /// Device is a [MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP747)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-13in-device.jpg)
     case macBookPro13Inch2016TwoThunderbolt3Ports
     /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2015)](https://support.apple.com/kb/SP719)
     ///
@@ -511,7 +511,7 @@ public enum Device {
     case macBookProRetina15InchMid2015
     /// Device is a [MacBook Pro (Retina, 13-inch, Early 2015)](https://support.apple.com/kb/SP715)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-2015-13in-device.jpg)
     case macBookProRetina13InchEarly2015
     /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704) or [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)
     ///
@@ -519,7 +519,7 @@ public enum Device {
     case macBookProRetina15InchMid2014
     /// Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703) or [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-13in-device.jpg)
     case macBookProRetina13InchMid2014
     /// Device is an [iMac Pro](https://support.apple.com/kb/SP771)
     ///

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -309,14 +309,10 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2010-device.jpg)
     case macMiniMid2010
-    /// Device is a [Mac mini (Late 2009)](https://support.apple.com/kb/SP577)
+    /// Device is a [Mac mini (Late 2009)](https://support.apple.com/kb/SP577) or [Mac mini (Early 2009)](https://support.apple.com/kb/SP505)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg)
-    case macMiniLate2009
-    /// Device is a [Mac mini (Early 2009)](https://support.apple.com/kb/SP505)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg)
-    case macMiniEarly2009
+    case macMini2009
     /// Device is a [iMac (Retina 5K, 27-inch, 2019)](https://support.apple.com/kb/SP790)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
@@ -349,14 +345,10 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
     case iMac215InchLate2015
-    /// Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718)
+    /// Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718) or [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
     case iMacRetina5K27InchMid2015
-    /// Device is a [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg)
-    case iMacRetina5K27InchLate2014
     /// Device is a [iMac (21.5-inch, Mid 2014)](https://support.apple.com/kb/SP701)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg)
@@ -389,22 +381,6 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg)
     case iMac215InchMid2010
-    /// Device is a [iMac (27-inch, Late 2009)](https://support.apple.com/kb/SP696)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
-    case iMac27InchLate2009
-    /// Device is a [iMac (21.5-inch, Late 2009)](https://support.apple.com/kb/SP576)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
-    case iMac215InchLate2009
-    /// Device is a [iMac (24-inch, Early 2009)](https://support.apple.com/kb/SP507)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
-    case iMac24InchEarly2009
-    /// Device is a [iMac (20-inch, Early 2009)](https://support.apple.com/kb/SP507)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
-    case iMac20InchEarly2009
     /// Device is a [Mac Pro (Mid 2012)](https://support.apple.com/kb/SP652)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/macpro_previous.png)
@@ -429,14 +405,6 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg)
     case macBook13InchLate2009
-    /// Device is a [MacBook (13-inch, Mid 2009)](https://support.apple.com/kb/SP512)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg)
-    case macBook13InchMid2009
-    /// Device is a [MacBook (13-inch, Early 2009)](https://support.apple.com/kb/SP504)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg)
-    case macBook13InchEarly2009
     /// Device is a [MacBook Air (Retina, 13-inch, 2019)](https://support.apple.com/kb/SP798)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2018-device.jpg)
@@ -457,22 +425,14 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg)
     case macBookAir11InchEarly2015
-    /// Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700)
+    /// Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700) or [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
     case macBookAir13InchEarly2014
-    /// Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699)
+    /// Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699) or [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
     case macBookAir11InchEarly2014
-    /// Device is a [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
-    case macBookAir13InchMid2013
-    /// Device is a [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
-    case macBookAir11InchMid2013
     /// Device is a [MacBook Air (13-inch, Mid 2012)](https://support.apple.com/kb/SP670)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg)
@@ -509,7 +469,7 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg)
     case macBookPro15Inch2019
-    /// Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795)
+    /// Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795) or [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg)
     case macBookPro13Inch2019FourThunderbolt3Ports
@@ -517,10 +477,6 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg)
     case macBookPro15Inch2018
-    /// Device is a [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg)
-    case macBookPro13Inch2018FourThunderbolt3Ports
     /// Device is a [MacBook Pro (15-inch, 2017)](https://support.apple.com/kb/SP756)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg)
@@ -553,114 +509,14 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg)
     case macBookProRetina13InchEarly2015
-    /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704)
+    /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704) or [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg)
     case macBookProRetina15InchMid2014
-    /// Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703)
+    /// Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703) or [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg)
     case macBookProRetina13InchMid2014
-    /// Device is a [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
-    case macBookProRetina15InchLate2013
-    /// Device is a [MacBook Pro (Retina, 15-inch, Early 2013)](https://support.apple.com/kb/SP669)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
-    case macBookProRetina15InchEarly2013
-    /// Device is a [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
-    case macBookProRetina13InchLate2013
-    /// Device is a [MacBook Pro (Retina, 13-inch, Early 2013)](https://support.apple.com/kb/SP668)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
-    case macBookProRetina13InchEarly2013
-    /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2012)](https://support.apple.com/kb/SP653)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
-    case macBookProRetina15InchMid2012
-    /// Device is a [MacBook Pro (15-inch, Mid 2012)](https://support.apple.com/kb/SP694)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
-    case macBookPro15InchMid2012
-    /// Device is a [MacBook Pro (Retina, 13-inch, Late 2012)](https://support.apple.com/kb/SP658)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
-    case macBookProRetina13InchLate2012
-    /// Device is a [MacBook Pro (13-inch, Mid 2012)](https://support.apple.com/kb/SP649)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
-    case macBookPro13InchMid2012
-    /// Device is a [MacBook Pro (17-inch, Late 2011)](https://support.apple.com/kb/SP646)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
-    case macBookPro17InchLate2011
-    /// Device is a [MacBook Pro (17-inch, Early 2011)](https://support.apple.com/kb/SP621)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
-    case macBookPro17InchEarly2011
-    /// Device is a [MacBook Pro (15-inch, Late 2011)](https://support.apple.com/kb/SP644)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
-    case macBookPro15InchLate2011
-    /// Device is a [MacBook Pro (15-inch, Early 2011)](https://support.apple.com/kb/SP620)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
-    case macBookPro15InchEarly2011
-    /// Device is a [MacBook Pro (13-inch, Late 2011)](https://support.apple.com/kb/SP645)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
-    case macBookPro13InchLate2011
-    /// Device is a [MacBook Pro (13-inch, Early 2011)](https://support.apple.com/kb/SP619)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
-    case macBookPro13InchEarly2011
-    /// Device is a [MacBook Pro (17-inch, Mid 2010)](https://support.apple.com/kb/SP581)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg)
-    case macBookPro17InchMid2010
-    /// Device is a [MacBook Pro (15-inch, Mid 2010)](https://support.apple.com/kb/SP582)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg)
-    case macBookPro15InchMid2010
-    /// Device is a [MacBook Pro (13-inch, Mid 2010)](https://support.apple.com/kb/SP583)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg)
-    case macBookPro13InchMid2010
-    /// Device is a [MacBook Pro (17-inch, Mid 2009)](https://support.apple.com/kb/SP546)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
-    case macBookPro17InchMid2009
-    /// Device is a [MacBook Pro (17-inch, Early 2009)](https://support.apple.com/kb/SP503)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
-    case macBookPro17InchEarly2009
-    /// Device is a [MacBook Pro (15-inch, Mid 2009)](https://support.apple.com/kb/SP544)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
-    case macBookPro15InchMid2009
-    /// Device is a [MacBook Pro (15-inch, 2.53GHz, Mid 2009)](https://support.apple.com/kb/SP544)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
-    case macBookPro15Inch253GHzMid2009
-    /// Device is a [MacBook Pro (13-inch, Mid 2009)](https://support.apple.com/kb/SP541)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
-    case macBookPro13InchMid2009
-    /// Device is a [MacBook Pro (15-inch, Late 2008)](https://support.apple.com/kb/SP499)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg)
-    case macBookPro15InchLate2008
-    /// Device is a [MacBook Pro (17-inch, Early 2008)](https://support.apple.com/kb/SP4)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg)
-    case macBookPro17InchEarly2008
-    /// Device is a [MacBook Pro (15-inch, Early 2008)](https://support.apple.com/kb/SP4)
-    ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg)
-    case macBookPro15InchEarly2008
     /// Device is an [iMac Pro](https://support.apple.com/kb/SP771)
     ///
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP771/SP771-imac-pro-2017.png)
@@ -786,11 +642,10 @@ public enum Device {
       switch identifier {
       case "Macmini8,1": return macMini2018
       case "Macmini7,1": return macMiniLate2014
-      case "Macmini6,1", " Macmini6,2": return macMiniLate2012
-      case "Macmini5,1", " Macmini5,2": return macMiniMid2011
+      case "Macmini6,1", "Macmini6,2": return macMiniLate2012
+      case "Macmini5,1", "Macmini5,2": return macMiniMid2011
       case "Macmini4,1": return macMiniMid2010
-      case "Macmini3,1": return macMiniLate2009
-      case "Macmini3,1": return macMiniEarly2009
+      case "Macmini3,1": return macMini2009
       case "iMac19,1": return iMacRetina5K27Inch2019
       case "iMac19,2": return iMacRetina4K215Inch2019
       case "iMac18,3": return iMacRetina5K27Inch2017
@@ -800,7 +655,6 @@ public enum Device {
       case "iMac16,2": return iMacRetina4K215InchLate2015
       case "iMac16,1": return iMac215InchLate2015
       case "iMac15,1": return iMacRetina5K27InchMid2015
-      case "iMac15,1": return iMacRetina5K27InchLate2014
       case "iMac14,4": return iMac215InchMid2014
       case "iMac14,2": return iMac27InchLate2013
       case "iMac14,1": return iMac215InchLate2013
@@ -809,27 +663,19 @@ public enum Device {
       case "iMac12,1": return iMac215InchMid2011
       case "iMac11,3": return iMac27InchMid2010
       case "iMac11,2": return iMac215InchMid2010
-      case "iMac10,1": return iMac27InchLate2009
-      case "iMac10,1": return iMac215InchLate2009
-      case "iMac9,1": return iMac24InchEarly2009
-      case "iMac9,1": return iMac20InchEarly2009
       case "MacPro5,1": return macProMid2012
       case "MacBook10,1": return macBookRetina12Inch2017
       case "MacBook9,1": return macBookRetina12InchEarly2016
       case "MacBook8,1": return macBookRetina12InchEarly2015
       case "MacBook7,1": return macBook13InchMid2010
       case "MacBook6,1": return macBook13InchLate2009
-      case "MacBook5,2": return macBook13InchMid2009
-      case "MacBook5,2": return macBook13InchEarly2009
       case "MacBookAir8,2": return macBookAirRetina13Inch2019
       case "MacBookAir8,1": return macBookAirRetina13Inch2018
-      case "MacBookAir7,2": return macBookAir13Inch2017
+      case "MacBookAir7,3": return macBookAir13Inch2017
       case "MacBookAir7,2": return macBookAir13InchEarly2015
       case "MacBookAir7,1": return macBookAir11InchEarly2015
       case "MacBookAir6,2": return macBookAir13InchEarly2014
       case "MacBookAir6,1": return macBookAir11InchEarly2014
-      case "MacBookAir6,2": return macBookAir13InchMid2013
-      case "MacBookAir6,1": return macBookAir11InchMid2013
       case "MacBookAir5,2": return macBookAir13InchMid2012
       case "MacBookAir5,1": return macBookAir11InchMid2012
       case "MacBookAir4,2": return macBookAir13InchMid2011
@@ -838,10 +684,9 @@ public enum Device {
       case "MacBookAir3,1": return macBookAir11InchLate2010
       case "MacBookAir2,1": return macBookAirMid2009
       case "MacBookPro15,4": return macBookPro13Inch2019TwoThunderbolt3Ports
-      case "MacBookPro15,1,": return macBookPro15Inch2019
+      case "MacBookPro15,3": return macBookPro15Inch2019
       case "MacBookPro15,2": return macBookPro13Inch2019FourThunderbolt3Ports
       case "MacBookPro15,1": return macBookPro15Inch2018
-      case "MacBookPro15,2": return macBookPro13Inch2018FourThunderbolt3Ports
       case "MacBookPro14,3": return macBookPro15Inch2017
       case "MacBookPro14,2": return macBookPro13Inch2017FourThunderbolt3Ports
       case "MacBookPro14,1": return macBookPro13Inch2017TwoThunderbolt3Ports
@@ -852,31 +697,6 @@ public enum Device {
       case "MacBookPro12,1": return macBookProRetina13InchEarly2015
       case "MacBookPro11,2": return macBookProRetina15InchMid2014
       case "MacBookPro11,1": return macBookProRetina13InchMid2014
-      case "MacBookPro11,2": return macBookProRetina15InchLate2013
-      case "MacBookPro10,1": return macBookProRetina15InchEarly2013
-      case "MacBookPro11,1": return macBookProRetina13InchLate2013
-      case "MacBookPro10,2": return macBookProRetina13InchEarly2013
-      case "MacBookPro10,1": return macBookProRetina15InchMid2012
-      case "MacBookPro9,1": return macBookPro15InchMid2012
-      case "MacBookPro10,2": return macBookProRetina13InchLate2012
-      case "MacBookPro9,2": return macBookPro13InchMid2012
-      case "MacBookPro8,3": return macBookPro17InchLate2011
-      case "MacBookPro8,3": return macBookPro17InchEarly2011
-      case "MacBookPro8,2": return macBookPro15InchLate2011
-      case "MacBookPro8,2": return macBookPro15InchEarly2011
-      case "MacBookPro8,1": return macBookPro13InchLate2011
-      case "MacBookPro8,1": return macBookPro13InchEarly2011
-      case "MacBookPro6,1": return macBookPro17InchMid2010
-      case "MacBookPro6,2": return macBookPro15InchMid2010
-      case "MacBookPro7,1": return macBookPro13InchMid2010
-      case "MacBookPro5,2": return macBookPro17InchMid2009
-      case "MacBookPro5,2": return macBookPro17InchEarly2009
-      case "MacBookPro5,3": return macBookPro15InchMid2009
-      case "MacBookPro5,3": return macBookPro15Inch253GHzMid2009
-      case "MacBookPro5,5": return macBookPro13InchMid2009
-      case "MacBookPro5,1": return macBookPro15InchLate2008
-      case "MacBookPro4,1": return macBookPro17InchEarly2008
-      case "MacBookPro4,1": return macBookPro15InchEarly2008
       case "iMacPro1,1": return iMacPro
       default: return unknown(identifier)
       }
@@ -1259,27 +1079,27 @@ public enum Device {
   #elseif os(macOS)
   /// All Macs
   public static var allMacs: [Device] {
-     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMiniLate2009, .macMiniEarly2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMacRetina5K27InchLate2014, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .iMac27InchLate2009, .iMac215InchLate2009, .iMac24InchEarly2009, .iMac20InchEarly2009, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBook13InchMid2009, .macBook13InchEarly2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2013, .macBookAir11InchMid2013, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro13Inch2018FourThunderbolt3Ports, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .macBookProRetina15InchLate2013, .macBookProRetina15InchEarly2013, .macBookProRetina13InchLate2013, .macBookProRetina13InchEarly2013, .macBookProRetina15InchMid2012, .macBookPro15InchMid2012, .macBookProRetina13InchLate2012, .macBookPro13InchMid2012, .macBookPro17InchLate2011, .macBookPro17InchEarly2011, .macBookPro15InchLate2011, .macBookPro15InchEarly2011, .macBookPro13InchLate2011, .macBookPro13InchEarly2011, .macBookPro17InchMid2010, .macBookPro15InchMid2010, .macBookPro13InchMid2010, .macBookPro17InchMid2009, .macBookPro17InchEarly2009, .macBookPro15InchMid2009, .macBookPro15Inch253GHzMid2009, .macBookPro13InchMid2009, .macBookPro15InchLate2008, .macBookPro17InchEarly2008, .macBookPro15InchEarly2008, .iMacPro]
+     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .iMacPro]
   }
 
   public static var allMacMinis: [Device] {
-     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMiniLate2009, .macMiniEarly2009]
+     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009]
   }
 
   public static var allMacBookAirs: [Device] {
-     return [.macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2013, .macBookAir11InchMid2013, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009]
+     return [.macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009]
   }
 
   public static var allMacBooks: [Device] {
-     return [.macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBook13InchMid2009, .macBook13InchEarly2009]
+     return [.macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009]
   }
 
   public static var allMacBookPros: [Device] {
-     return [.macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro13Inch2018FourThunderbolt3Ports, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .macBookProRetina15InchLate2013, .macBookProRetina15InchEarly2013, .macBookProRetina13InchLate2013, .macBookProRetina13InchEarly2013, .macBookProRetina15InchMid2012, .macBookPro15InchMid2012, .macBookProRetina13InchLate2012, .macBookPro13InchMid2012, .macBookPro17InchLate2011, .macBookPro17InchEarly2011, .macBookPro15InchLate2011, .macBookPro15InchEarly2011, .macBookPro13InchLate2011, .macBookPro13InchEarly2011, .macBookPro17InchMid2010, .macBookPro15InchMid2010, .macBookPro13InchMid2010, .macBookPro17InchMid2009, .macBookPro17InchEarly2009, .macBookPro15InchMid2009, .macBookPro15Inch253GHzMid2009, .macBookPro13InchMid2009, .macBookPro15InchLate2008, .macBookPro17InchEarly2008, .macBookPro15InchEarly2008]
+     return [.macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014]
   }
 
   public static var allIMacs: [Device] {
-     return [.iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMacRetina5K27InchLate2014, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .iMac27InchLate2009, .iMac215InchLate2009, .iMac24InchEarly2009, .iMac20InchEarly2009]
+     return [.iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010]
   }
 
   public static var allIMacPros: [Device] {
@@ -1381,7 +1201,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().name
     #elseif os(macOS)
-    return nil
+    return description
     #else
     return UIDevice.current.name
     #endif
@@ -1393,7 +1213,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
     #elseif os(macOS)
-    return nil
+    return "macOS"
     #else
     return UIDevice.current.systemName
     #endif
@@ -1405,7 +1225,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().systemVersion
     #elseif os(macOS)
-    return nil
+    return ProcessInfo.processInfo.operatingSystemVersionString
     #else
     return UIDevice.current.systemVersion
     #endif
@@ -1417,7 +1237,9 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().model
     #elseif os(macOS)
-    return nil
+    var set = CharacterSet.decimalDigits
+    set.insert(",")
+    return Device.identifier.components(separatedBy: set).joined()
     #else
     return UIDevice.current.model
     #endif
@@ -1429,7 +1251,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().localizedModel
     #elseif os(macOS)
-    return nil
+    return model
     #else
     return UIDevice.current.localizedModel
     #endif
@@ -1620,8 +1442,7 @@ extension Device: CustomStringConvertible {
       case .macMiniLate2012: return "Mac mini (Late 2012)"
       case .macMiniMid2011: return "Mac mini (Mid 2011)"
       case .macMiniMid2010: return "Mac mini (Mid 2010)"
-      case .macMiniLate2009: return "Mac mini (Late 2009)"
-      case .macMiniEarly2009: return "Mac mini (Early 2009)"
+      case .macMini2009: return "Mac mini (2009)"
       case .iMacRetina5K27Inch2019: return "iMac (Retina 5K, 27-inch, 2019)"
       case .iMacRetina4K215Inch2019: return "iMac (Retina 4K, 21.5-inch, 2019)"
       case .iMacRetina5K27Inch2017: return "iMac (Retina 5K, 27-inch, 2017)"
@@ -1630,8 +1451,7 @@ extension Device: CustomStringConvertible {
       case .iMacRetina5K27InchLate2015: return "iMac (Retina 5K, 27-inch, Late 2015)"
       case .iMacRetina4K215InchLate2015: return "iMac (Retina 4K, 21.5-inch, Late 2015)"
       case .iMac215InchLate2015: return "iMac (21.5-inch, Late 2015)"
-      case .iMacRetina5K27InchMid2015: return "iMac (Retina 5K, 27-inch, Mid 2015)"
-      case .iMacRetina5K27InchLate2014: return "iMac (Retina 5K, 27-inch, Late 2014)"
+      case .iMacRetina5K27InchMid2015: return "iMac (Retina 5K, 27-inch)"
       case .iMac215InchMid2014: return "iMac (21.5-inch, Mid 2014)"
       case .iMac27InchLate2013: return "iMac (27-inch, Late 2013)"
       case .iMac215InchLate2013: return "iMac (21.5-inch, Late 2013)"
@@ -1640,18 +1460,12 @@ extension Device: CustomStringConvertible {
       case .iMac215InchMid2011: return "iMac (21.5-inch, Mid 2011)"
       case .iMac27InchMid2010: return "iMac (27-inch, Mid 2010)"
       case .iMac215InchMid2010: return "iMac (21.5-inch, Mid 2010)"
-      case .iMac27InchLate2009: return "iMac (27-inch, Late 2009)"
-      case .iMac215InchLate2009: return "iMac (21.5-inch, Late 2009)"
-      case .iMac24InchEarly2009: return "iMac (24-inch, Early 2009)"
-      case .iMac20InchEarly2009: return "iMac (20-inch, Early 2009)"
       case .macProMid2012: return "Mac Pro (Mid 2012)"
       case .macBookRetina12Inch2017: return "MacBook (Retina, 12-inch, 2017)"
       case .macBookRetina12InchEarly2016: return "MacBook (Retina, 12-inch, Early 2016)"
       case .macBookRetina12InchEarly2015: return "MacBook (Retina, 12-inch, Early 2015)"
       case .macBook13InchMid2010: return "MacBook (13-inch, Mid 2010)"
       case .macBook13InchLate2009: return "MacBook (13-inch, Late 2009)"
-      case .macBook13InchMid2009: return "MacBook (13-inch, Mid 2009)"
-      case .macBook13InchEarly2009: return "MacBook (13-inch, Early 2009)"
       case .macBookAirRetina13Inch2019: return "MacBook Air (Retina, 13-inch, 2019)"
       case .macBookAirRetina13Inch2018: return "MacBook Air (Retina, 13-inch, 2018)"
       case .macBookAir13Inch2017: return "MacBook Air (13-inch, 2017)"
@@ -1659,8 +1473,6 @@ extension Device: CustomStringConvertible {
       case .macBookAir11InchEarly2015: return "MacBook Air (11-inch, Early 2015)"
       case .macBookAir13InchEarly2014: return "MacBook Air (13-inch, Early 2014)"
       case .macBookAir11InchEarly2014: return "MacBook Air (11-inch, Early 2014)"
-      case .macBookAir13InchMid2013: return "MacBook Air (13-inch, Mid 2013)"
-      case .macBookAir11InchMid2013: return "MacBook Air (11-inch, Mid 2013)"
       case .macBookAir13InchMid2012: return "MacBook Air (13-inch, Mid 2012)"
       case .macBookAir11InchMid2012: return "MacBook Air (11-inch, Mid 2012)"
       case .macBookAir13InchMid2011: return "MacBook Air (13-inch, Mid 2011)"
@@ -1672,7 +1484,6 @@ extension Device: CustomStringConvertible {
       case .macBookPro15Inch2019: return "MacBook Pro (15-inch, 2019)"
       case .macBookPro13Inch2019FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)"
       case .macBookPro15Inch2018: return "MacBook Pro (15-inch, 2018)"
-      case .macBookPro13Inch2018FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)"
       case .macBookPro15Inch2017: return "MacBook Pro (15-inch, 2017)"
       case .macBookPro13Inch2017FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)"
       case .macBookPro13Inch2017TwoThunderbolt3Ports: return "MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)"
@@ -1683,31 +1494,6 @@ extension Device: CustomStringConvertible {
       case .macBookProRetina13InchEarly2015: return "MacBook Pro (Retina, 13-inch, Early 2015)"
       case .macBookProRetina15InchMid2014: return "MacBook Pro (Retina, 15-inch, Mid 2014)"
       case .macBookProRetina13InchMid2014: return "MacBook Pro (Retina, 13-inch, Mid 2014)"
-      case .macBookProRetina15InchLate2013: return "MacBook Pro (Retina, 15-inch, Late 2013)"
-      case .macBookProRetina15InchEarly2013: return "MacBook Pro (Retina, 15-inch, Early 2013)"
-      case .macBookProRetina13InchLate2013: return "MacBook Pro (Retina, 13-inch, Late 2013)"
-      case .macBookProRetina13InchEarly2013: return "MacBook Pro (Retina, 13-inch, Early 2013)"
-      case .macBookProRetina15InchMid2012: return "MacBook Pro (Retina, 15-inch, Mid 2012)"
-      case .macBookPro15InchMid2012: return "MacBook Pro (15-inch, Mid 2012)"
-      case .macBookProRetina13InchLate2012: return "MacBook Pro (Retina, 13-inch, Late 2012)"
-      case .macBookPro13InchMid2012: return "MacBook Pro (13-inch, Mid 2012)"
-      case .macBookPro17InchLate2011: return "MacBook Pro (17-inch, Late 2011)"
-      case .macBookPro17InchEarly2011: return "MacBook Pro (17-inch, Early 2011)"
-      case .macBookPro15InchLate2011: return "MacBook Pro (15-inch, Late 2011)"
-      case .macBookPro15InchEarly2011: return "MacBook Pro (15-inch, Early 2011)"
-      case .macBookPro13InchLate2011: return "MacBook Pro (13-inch, Late 2011)"
-      case .macBookPro13InchEarly2011: return "MacBook Pro (13-inch, Early 2011)"
-      case .macBookPro17InchMid2010: return "MacBook Pro (17-inch, Mid 2010)"
-      case .macBookPro15InchMid2010: return "MacBook Pro (15-inch, Mid 2010)"
-      case .macBookPro13InchMid2010: return "MacBook Pro (13-inch, Mid 2010)"
-      case .macBookPro17InchMid2009: return "MacBook Pro (17-inch, Mid 2009)"
-      case .macBookPro17InchEarly2009: return "MacBook Pro (17-inch, Early 2009)"
-      case .macBookPro15InchMid2009: return "MacBook Pro (15-inch, Mid 2009)"
-      case .macBookPro15Inch253GHzMid2009: return "MacBook Pro (15-inch, 2.53GHz, Mid 2009)"
-      case .macBookPro13InchMid2009: return "MacBook Pro (13-inch, Mid 2009)"
-      case .macBookPro15InchLate2008: return "MacBook Pro (15-inch, Late 2008)"
-      case .macBookPro17InchEarly2008: return "MacBook Pro (17-inch, Early 2008)"
-      case .macBookPro15InchEarly2008: return "MacBook Pro (15-inch, Early 2008)"
       case .iMacPro: return "iMac Pro (2017)"
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -794,7 +794,7 @@ public enum Device {
       case .unknown: return -1
       }
     #elseif os(macOS)
-    return -1
+      return -1
     #endif
   }
   #endif

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -11,6 +11,8 @@
 
 #if os(watchOS)
 import WatchKit
+#elseif os(macOS)
+import AppKit
 #else
 import UIKit
 #endif
@@ -286,6 +288,7 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP808/sp808-apple-watch-series-5_2x.png)
     case appleWatchSeries5_44mm
+  #elseif os(macOS)
   #endif
 
   /// Device is [Simulator](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/iOS_Simulator_Guide/Introduction/Introduction.html)
@@ -396,6 +399,8 @@ public enum Device {
       case "i386", "x86_64": return simulator(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "watchOS"))
       default: return unknown(identifier)
       }
+    #elseif os(macOS)
+    return unknown(identifier)
     #endif
   }
 
@@ -484,6 +489,8 @@ public enum Device {
       case .simulator(let model): return model.diagonal
       case .unknown: return -1
       }
+    #elseif os(macOS)
+    return -1
     #endif
   }
   #endif
@@ -558,6 +565,8 @@ public enum Device {
       case .unknown: return (width: -1, height: -1)
       }
     #elseif os(tvOS)
+      return (width: -1, height: -1)
+    #elseif os(macOS)
       return (width: -1, height: -1)
     #endif
   }
@@ -778,6 +787,8 @@ public enum Device {
       return allTVs
     #elseif os(watchOS)
       return allWatches
+    #elseif os(macOS)
+      return []
     #endif
   }
 
@@ -829,6 +840,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().name
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.name
     #endif
@@ -839,6 +852,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.systemName
     #endif
@@ -849,6 +864,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().systemVersion
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.systemVersion
     #endif
@@ -859,6 +876,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().model
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.model
     #endif
@@ -869,6 +888,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().localizedModel
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.localizedModel
     #endif
@@ -944,6 +965,8 @@ public enum Device {
     case .unknown: return nil
     }
     #elseif os(tvOS)
+    return nil
+    #elseif os(macOS)
     return nil
     #endif
   }
@@ -1047,6 +1070,11 @@ extension Device: CustomStringConvertible {
       switch self {
       case .appleTVHD: return "Apple TV HD"
       case .appleTV4K: return "Apple TV 4K"
+      case .simulator(let model): return "Simulator (\(model))"
+      case .unknown(let identifier): return identifier
+      }
+    #elseif os(macOS)
+      switch self {
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier
       }

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -289,6 +289,382 @@ public enum Device {
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP808/sp808-apple-watch-series-5_2x.png)
     case appleWatchSeries5_44mm
   #elseif os(macOS)
+    /// Device is a [Mac mini (2018)](https://support.apple.com/kb/SP782)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2018-space-gray.jpg)
+    case macMini2018
+    /// Device is a [Mac mini (Late 2014)](https://support.apple.com/kb/SP710)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2014.jpg)
+    case macMiniLate2014
+    /// Device is a [Mac mini (Late 2012)](https://support.apple.com/kb/SP659)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg)
+    case macMiniLate2012
+    /// Device is a [Mac mini (Mid 2011)](https://support.apple.com/kb/SP632)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg)
+    case macMiniMid2011
+    /// Device is a [Mac mini (Mid 2010)](https://support.apple.com/kb/SP585)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2010-device.jpg)
+    case macMiniMid2010
+    /// Device is a [Mac mini (Late 2009)](https://support.apple.com/kb/SP577)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg)
+    case macMiniLate2009
+    /// Device is a [Mac mini (Early 2009)](https://support.apple.com/kb/SP505)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg)
+    case macMiniEarly2009
+    /// Device is a [iMac (Retina 5K, 27-inch, 2019)](https://support.apple.com/kb/SP790)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    case iMacRetina5K27Inch2019
+    /// Device is a [iMac (Retina 4K, 21.5-inch, 2019)](https://support.apple.com/kb/SP789)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    case iMacRetina4K215Inch2019
+    /// Device is a [iMac (Retina 5K, 27-inch, 2017)](https://support.apple.com/kb/SP760)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    case iMacRetina5K27Inch2017
+    /// Device is a [iMac (Retina 4K, 21.5-inch, 2017)](https://support.apple.com/kb/SP759)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    case iMacRetina4K215Inch2017
+    /// Device is a [iMac (21.5-inch, 2017)](https://support.apple.com/kb/SP758)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg)
+    case iMac215Inch2017
+    /// Device is a [iMac (Retina 5K, 27-inch, Late 2015)](https://support.apple.com/kb/SP731)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
+    case iMacRetina5K27InchLate2015
+    /// Device is a [iMac (Retina 4K, 21.5-inch, Late 2015)](https://support.apple.com/kb/SP732)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
+    case iMacRetina4K215InchLate2015
+    /// Device is a [iMac (21.5-inch, Late 2015)](https://support.apple.com/kb/SP733)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
+    case iMac215InchLate2015
+    /// Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg)
+    case iMacRetina5K27InchMid2015
+    /// Device is a [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg)
+    case iMacRetina5K27InchLate2014
+    /// Device is a [iMac (21.5-inch, Mid 2014)](https://support.apple.com/kb/SP701)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg)
+    case iMac215InchMid2014
+    /// Device is a [iMac (27-inch, Late 2013)](https://support.apple.com/kb/SP688)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2013.jpg)
+    case iMac27InchLate2013
+    /// Device is a [iMac (21.5-inch, Late 2013)](https://support.apple.com/kb/SP687)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2013.jpg)
+    case iMac215InchLate2013
+    /// Device is a [iMac (21.5-inch, Late 2012)](https://support.apple.com/kb/SP665)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2012.jpg)
+    case iMac215InchLate2012
+    /// Device is a [iMac (27-inch, Mid 2011)](https://support.apple.com/kb/SP689)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2011.jpg)
+    case iMac27InchMid2011
+    /// Device is a [iMac (21.5-inch, Mid 2011)](https://support.apple.com/kb/SP623)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2011.jpg)
+    case iMac215InchMid2011
+    /// Device is a [iMac (27-inch, Mid 2010)](https://support.apple.com/kb/SP695)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg)
+    case iMac27InchMid2010
+    /// Device is a [iMac (21.5-inch, Mid 2010)](https://support.apple.com/kb/SP588)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg)
+    case iMac215InchMid2010
+    /// Device is a [iMac (27-inch, Late 2009)](https://support.apple.com/kb/SP696)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
+    case iMac27InchLate2009
+    /// Device is a [iMac (21.5-inch, Late 2009)](https://support.apple.com/kb/SP576)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
+    case iMac215InchLate2009
+    /// Device is a [iMac (24-inch, Early 2009)](https://support.apple.com/kb/SP507)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
+    case iMac24InchEarly2009
+    /// Device is a [iMac (20-inch, Early 2009)](https://support.apple.com/kb/SP507)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg)
+    case iMac20InchEarly2009
+    /// Device is a [Mac Pro (Mid 2012)](https://support.apple.com/kb/SP652)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/macpro_previous.png)
+    case macProMid2012
+    /// Device is a [MacBook (Retina, 12-inch, 2017)](https://support.apple.com/kb/SP757)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2017-device.jpg)
+    case macBookRetina12Inch2017
+    /// Device is a [MacBook (Retina, 12-inch, Early 2016)](https://support.apple.com/kb/SP741)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2016-device.jpg)
+    case macBookRetina12InchEarly2016
+    /// Device is a [MacBook (Retina, 12-inch, Early 2015)](https://support.apple.com/kb/SP712)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2015-device.jpg)
+    case macBookRetina12InchEarly2015
+    /// Device is a [MacBook (13-inch, Mid 2010)](https://support.apple.com/kb/SP584)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg)
+    case macBook13InchMid2010
+    /// Device is a [MacBook (13-inch, Late 2009)](https://support.apple.com/kb/SP579)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg)
+    case macBook13InchLate2009
+    /// Device is a [MacBook (13-inch, Mid 2009)](https://support.apple.com/kb/SP512)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg)
+    case macBook13InchMid2009
+    /// Device is a [MacBook (13-inch, Early 2009)](https://support.apple.com/kb/SP504)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg)
+    case macBook13InchEarly2009
+    /// Device is a [MacBook Air (Retina, 13-inch, 2019)](https://support.apple.com/kb/SP798)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2018-device.jpg)
+    case macBookAirRetina13Inch2019
+    /// Device is a [MacBook Air (Retina, 13-inch, 2018)](https://support.apple.com/kb/SP783)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2018-device.jpg)
+    case macBookAirRetina13Inch2018
+    /// Device is a [MacBook Air (13-inch, 2017)](https://support.apple.com/kb/SP753)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2017-device.jpg)
+    case macBookAir13Inch2017
+    /// Device is a [MacBook Air (13-inch, Early 2015)](https://support.apple.com/kb/SP714)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg)
+    case macBookAir13InchEarly2015
+    /// Device is a [MacBook Air (11-inch, Early 2015)](https://support.apple.com/kb/SP713)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg)
+    case macBookAir11InchEarly2015
+    /// Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
+    case macBookAir13InchEarly2014
+    /// Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
+    case macBookAir11InchEarly2014
+    /// Device is a [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
+    case macBookAir13InchMid2013
+    /// Device is a [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg)
+    case macBookAir11InchMid2013
+    /// Device is a [MacBook Air (13-inch, Mid 2012)](https://support.apple.com/kb/SP670)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg)
+    case macBookAir13InchMid2012
+    /// Device is a [MacBook Air (11-inch, Mid 2012)](https://support.apple.com/kb/SP650)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg)
+    case macBookAir11InchMid2012
+    /// Device is a [MacBook Air (13-inch, Mid 2011)](https://support.apple.com/kb/SP683)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-13in-device.jpg)
+    case macBookAir13InchMid2011
+    /// Device is a [MacBook Air (11-inch, Mid 2011)](https://support.apple.com/kb/SP631)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-13in-device.jpg)
+    case macBookAir11InchMid2011
+    /// Device is a [MacBook Air (13-inch, Late 2010)](https://support.apple.com/kb/SP618)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg)
+    case macBookAir13InchLate2010
+    /// Device is a [MacBook Air (11-inch, Late 2010)](https://support.apple.com/kb/SP617)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg)
+    case macBookAir11InchLate2010
+    /// Device is a [MacBook Air (Mid 2009)](https://support.apple.com/kb/SP548)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg)
+    case macBookAirMid2009
+    /// Device is a [MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP799)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg)
+    case macBookPro13Inch2019TwoThunderbolt3Ports
+    /// Device is a [MacBook Pro (15-inch, 2019)](https://support.apple.com/kb/SP794)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg)
+    case macBookPro15Inch2019
+    /// Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg)
+    case macBookPro13Inch2019FourThunderbolt3Ports
+    /// Device is a [MacBook Pro (15-inch, 2018)](https://support.apple.com/kb/SP776)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg)
+    case macBookPro15Inch2018
+    /// Device is a [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg)
+    case macBookPro13Inch2018FourThunderbolt3Ports
+    /// Device is a [MacBook Pro (15-inch, 2017)](https://support.apple.com/kb/SP756)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg)
+    case macBookPro15Inch2017
+    /// Device is a [MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP755)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg)
+    case macBookPro13Inch2017FourThunderbolt3Ports
+    /// Device is a [MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP754)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg)
+    case macBookPro13Inch2017TwoThunderbolt3Ports
+    /// Device is a [MacBook Pro (15-inch, 2016)](https://support.apple.com/kb/SP749)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg)
+    case macBookPro15Inch2016
+    /// Device is a [MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP748)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg)
+    case macBookPro13Inch2016FourThunderbolt3Ports
+    /// Device is a [MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP747)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg)
+    case macBookPro13Inch2016TwoThunderbolt3Ports
+    /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2015)](https://support.apple.com/kb/SP719)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg)
+    case macBookProRetina15InchMid2015
+    /// Device is a [MacBook Pro (Retina, 13-inch, Early 2015)](https://support.apple.com/kb/SP715)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg)
+    case macBookProRetina13InchEarly2015
+    /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg)
+    case macBookProRetina15InchMid2014
+    /// Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg)
+    case macBookProRetina13InchMid2014
+    /// Device is a [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
+    case macBookProRetina15InchLate2013
+    /// Device is a [MacBook Pro (Retina, 15-inch, Early 2013)](https://support.apple.com/kb/SP669)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
+    case macBookProRetina15InchEarly2013
+    /// Device is a [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
+    case macBookProRetina13InchLate2013
+    /// Device is a [MacBook Pro (Retina, 13-inch, Early 2013)](https://support.apple.com/kb/SP668)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg)
+    case macBookProRetina13InchEarly2013
+    /// Device is a [MacBook Pro (Retina, 15-inch, Mid 2012)](https://support.apple.com/kb/SP653)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
+    case macBookProRetina15InchMid2012
+    /// Device is a [MacBook Pro (15-inch, Mid 2012)](https://support.apple.com/kb/SP694)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
+    case macBookPro15InchMid2012
+    /// Device is a [MacBook Pro (Retina, 13-inch, Late 2012)](https://support.apple.com/kb/SP658)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
+    case macBookProRetina13InchLate2012
+    /// Device is a [MacBook Pro (13-inch, Mid 2012)](https://support.apple.com/kb/SP649)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg)
+    case macBookPro13InchMid2012
+    /// Device is a [MacBook Pro (17-inch, Late 2011)](https://support.apple.com/kb/SP646)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
+    case macBookPro17InchLate2011
+    /// Device is a [MacBook Pro (17-inch, Early 2011)](https://support.apple.com/kb/SP621)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
+    case macBookPro17InchEarly2011
+    /// Device is a [MacBook Pro (15-inch, Late 2011)](https://support.apple.com/kb/SP644)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
+    case macBookPro15InchLate2011
+    /// Device is a [MacBook Pro (15-inch, Early 2011)](https://support.apple.com/kb/SP620)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
+    case macBookPro15InchEarly2011
+    /// Device is a [MacBook Pro (13-inch, Late 2011)](https://support.apple.com/kb/SP645)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
+    case macBookPro13InchLate2011
+    /// Device is a [MacBook Pro (13-inch, Early 2011)](https://support.apple.com/kb/SP619)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg)
+    case macBookPro13InchEarly2011
+    /// Device is a [MacBook Pro (17-inch, Mid 2010)](https://support.apple.com/kb/SP581)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg)
+    case macBookPro17InchMid2010
+    /// Device is a [MacBook Pro (15-inch, Mid 2010)](https://support.apple.com/kb/SP582)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg)
+    case macBookPro15InchMid2010
+    /// Device is a [MacBook Pro (13-inch, Mid 2010)](https://support.apple.com/kb/SP583)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg)
+    case macBookPro13InchMid2010
+    /// Device is a [MacBook Pro (17-inch, Mid 2009)](https://support.apple.com/kb/SP546)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
+    case macBookPro17InchMid2009
+    /// Device is a [MacBook Pro (17-inch, Early 2009)](https://support.apple.com/kb/SP503)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
+    case macBookPro17InchEarly2009
+    /// Device is a [MacBook Pro (15-inch, Mid 2009)](https://support.apple.com/kb/SP544)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
+    case macBookPro15InchMid2009
+    /// Device is a [MacBook Pro (15-inch, 2.53GHz, Mid 2009)](https://support.apple.com/kb/SP544)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
+    case macBookPro15Inch253GHzMid2009
+    /// Device is a [MacBook Pro (13-inch, Mid 2009)](https://support.apple.com/kb/SP541)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg)
+    case macBookPro13InchMid2009
+    /// Device is a [MacBook Pro (15-inch, Late 2008)](https://support.apple.com/kb/SP499)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg)
+    case macBookPro15InchLate2008
+    /// Device is a [MacBook Pro (17-inch, Early 2008)](https://support.apple.com/kb/SP4)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg)
+    case macBookPro17InchEarly2008
+    /// Device is a [MacBook Pro (15-inch, Early 2008)](https://support.apple.com/kb/SP4)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg)
+    case macBookPro15InchEarly2008
+    /// Device is an [iMac Pro](https://support.apple.com/kb/SP771)
+    ///
+    /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP771/SP771-imac-pro-2017.png)
+    case iMacPro
   #endif
 
   /// Device is [Simulator](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/iOS_Simulator_Guide/Introduction/Introduction.html)
@@ -308,6 +684,12 @@ public enum Device {
 
   /// Gets the identifier from the system, such as "iPhone7,1".
   public static var identifier: String = {
+    #if os(macOS)
+    let identifier = try? sysctlData(for: [CTL_HW, HW_MODEL]).withUnsafeBufferPointer { dataPointer -> String? in
+        dataPointer.baseAddress.flatMap { String(validatingUTF8: $0) }
+    }
+    return identifier ?? ""
+    #else
     var systemInfo = utsname()
     uname(&systemInfo)
     let mirror = Mirror(reflecting: systemInfo.machine)
@@ -317,6 +699,7 @@ public enum Device {
       return identifier + String(UnicodeScalar(UInt8(value)))
     }
     return identifier
+    #endif
   }()
 
   /// Maps an identifier to a Device. If the identifier can not be mapped to an existing device, `UnknownDevice(identifier)` is returned.
@@ -400,7 +783,103 @@ public enum Device {
       default: return unknown(identifier)
       }
     #elseif os(macOS)
-    return unknown(identifier)
+      switch identifier {
+      case "Macmini8,1": return macMini2018
+      case "Macmini7,1": return macMiniLate2014
+      case "Macmini6,1", " Macmini6,2": return macMiniLate2012
+      case "Macmini5,1", " Macmini5,2": return macMiniMid2011
+      case "Macmini4,1": return macMiniMid2010
+      case "Macmini3,1": return macMiniLate2009
+      case "Macmini3,1": return macMiniEarly2009
+      case "iMac19,1": return iMacRetina5K27Inch2019
+      case "iMac19,2": return iMacRetina4K215Inch2019
+      case "iMac18,3": return iMacRetina5K27Inch2017
+      case "iMac18,2": return iMacRetina4K215Inch2017
+      case "iMac18,1": return iMac215Inch2017
+      case "iMac17,1": return iMacRetina5K27InchLate2015
+      case "iMac16,2": return iMacRetina4K215InchLate2015
+      case "iMac16,1": return iMac215InchLate2015
+      case "iMac15,1": return iMacRetina5K27InchMid2015
+      case "iMac15,1": return iMacRetina5K27InchLate2014
+      case "iMac14,4": return iMac215InchMid2014
+      case "iMac14,2": return iMac27InchLate2013
+      case "iMac14,1": return iMac215InchLate2013
+      case "iMac13,1": return iMac215InchLate2012
+      case "iMac12,2": return iMac27InchMid2011
+      case "iMac12,1": return iMac215InchMid2011
+      case "iMac11,3": return iMac27InchMid2010
+      case "iMac11,2": return iMac215InchMid2010
+      case "iMac10,1": return iMac27InchLate2009
+      case "iMac10,1": return iMac215InchLate2009
+      case "iMac9,1": return iMac24InchEarly2009
+      case "iMac9,1": return iMac20InchEarly2009
+      case "MacPro5,1": return macProMid2012
+      case "MacBook10,1": return macBookRetina12Inch2017
+      case "MacBook9,1": return macBookRetina12InchEarly2016
+      case "MacBook8,1": return macBookRetina12InchEarly2015
+      case "MacBook7,1": return macBook13InchMid2010
+      case "MacBook6,1": return macBook13InchLate2009
+      case "MacBook5,2": return macBook13InchMid2009
+      case "MacBook5,2": return macBook13InchEarly2009
+      case "MacBookAir8,2": return macBookAirRetina13Inch2019
+      case "MacBookAir8,1": return macBookAirRetina13Inch2018
+      case "MacBookAir7,2": return macBookAir13Inch2017
+      case "MacBookAir7,2": return macBookAir13InchEarly2015
+      case "MacBookAir7,1": return macBookAir11InchEarly2015
+      case "MacBookAir6,2": return macBookAir13InchEarly2014
+      case "MacBookAir6,1": return macBookAir11InchEarly2014
+      case "MacBookAir6,2": return macBookAir13InchMid2013
+      case "MacBookAir6,1": return macBookAir11InchMid2013
+      case "MacBookAir5,2": return macBookAir13InchMid2012
+      case "MacBookAir5,1": return macBookAir11InchMid2012
+      case "MacBookAir4,2": return macBookAir13InchMid2011
+      case "MacBookAir4,1": return macBookAir11InchMid2011
+      case "MacBookAir3,2": return macBookAir13InchLate2010
+      case "MacBookAir3,1": return macBookAir11InchLate2010
+      case "MacBookAir2,1": return macBookAirMid2009
+      case "MacBookPro15,4": return macBookPro13Inch2019TwoThunderbolt3Ports
+      case "MacBookPro15,1,": return macBookPro15Inch2019
+      case "MacBookPro15,2": return macBookPro13Inch2019FourThunderbolt3Ports
+      case "MacBookPro15,1": return macBookPro15Inch2018
+      case "MacBookPro15,2": return macBookPro13Inch2018FourThunderbolt3Ports
+      case "MacBookPro14,3": return macBookPro15Inch2017
+      case "MacBookPro14,2": return macBookPro13Inch2017FourThunderbolt3Ports
+      case "MacBookPro14,1": return macBookPro13Inch2017TwoThunderbolt3Ports
+      case "MacBookPro13,3": return macBookPro15Inch2016
+      case "MacBookPro13,2": return macBookPro13Inch2016FourThunderbolt3Ports
+      case "MacBookPro13,1": return macBookPro13Inch2016TwoThunderbolt3Ports
+      case "MacBookPro11,4": return macBookProRetina15InchMid2015
+      case "MacBookPro12,1": return macBookProRetina13InchEarly2015
+      case "MacBookPro11,2": return macBookProRetina15InchMid2014
+      case "MacBookPro11,1": return macBookProRetina13InchMid2014
+      case "MacBookPro11,2": return macBookProRetina15InchLate2013
+      case "MacBookPro10,1": return macBookProRetina15InchEarly2013
+      case "MacBookPro11,1": return macBookProRetina13InchLate2013
+      case "MacBookPro10,2": return macBookProRetina13InchEarly2013
+      case "MacBookPro10,1": return macBookProRetina15InchMid2012
+      case "MacBookPro9,1": return macBookPro15InchMid2012
+      case "MacBookPro10,2": return macBookProRetina13InchLate2012
+      case "MacBookPro9,2": return macBookPro13InchMid2012
+      case "MacBookPro8,3": return macBookPro17InchLate2011
+      case "MacBookPro8,3": return macBookPro17InchEarly2011
+      case "MacBookPro8,2": return macBookPro15InchLate2011
+      case "MacBookPro8,2": return macBookPro15InchEarly2011
+      case "MacBookPro8,1": return macBookPro13InchLate2011
+      case "MacBookPro8,1": return macBookPro13InchEarly2011
+      case "MacBookPro6,1": return macBookPro17InchMid2010
+      case "MacBookPro6,2": return macBookPro15InchMid2010
+      case "MacBookPro7,1": return macBookPro13InchMid2010
+      case "MacBookPro5,2": return macBookPro17InchMid2009
+      case "MacBookPro5,2": return macBookPro17InchEarly2009
+      case "MacBookPro5,3": return macBookPro15InchMid2009
+      case "MacBookPro5,3": return macBookPro15Inch253GHzMid2009
+      case "MacBookPro5,5": return macBookPro13InchMid2009
+      case "MacBookPro5,1": return macBookPro15InchLate2008
+      case "MacBookPro4,1": return macBookPro17InchEarly2008
+      case "MacBookPro4,1": return macBookPro15InchEarly2008
+      case "iMacPro1,1": return iMacPro
+      default: return unknown(identifier)
+      }
     #endif
   }
 
@@ -777,6 +1256,67 @@ public enum Device {
     public var hasForceTouchSupport: Bool {
       return isOneOf(Device.allWatchesWithForceTouchSupport)
     }
+  #elseif os(macOS)
+  /// All Macs
+  public static var allMacs: [Device] {
+     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMiniLate2009, .macMiniEarly2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMacRetina5K27InchLate2014, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .iMac27InchLate2009, .iMac215InchLate2009, .iMac24InchEarly2009, .iMac20InchEarly2009, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBook13InchMid2009, .macBook13InchEarly2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2013, .macBookAir11InchMid2013, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro13Inch2018FourThunderbolt3Ports, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .macBookProRetina15InchLate2013, .macBookProRetina15InchEarly2013, .macBookProRetina13InchLate2013, .macBookProRetina13InchEarly2013, .macBookProRetina15InchMid2012, .macBookPro15InchMid2012, .macBookProRetina13InchLate2012, .macBookPro13InchMid2012, .macBookPro17InchLate2011, .macBookPro17InchEarly2011, .macBookPro15InchLate2011, .macBookPro15InchEarly2011, .macBookPro13InchLate2011, .macBookPro13InchEarly2011, .macBookPro17InchMid2010, .macBookPro15InchMid2010, .macBookPro13InchMid2010, .macBookPro17InchMid2009, .macBookPro17InchEarly2009, .macBookPro15InchMid2009, .macBookPro15Inch253GHzMid2009, .macBookPro13InchMid2009, .macBookPro15InchLate2008, .macBookPro17InchEarly2008, .macBookPro15InchEarly2008, .iMacPro]
+  }
+
+  public static var allMacMinis: [Device] {
+     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMiniLate2009, .macMiniEarly2009]
+  }
+
+  public static var allMacBookAirs: [Device] {
+     return [.macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2013, .macBookAir11InchMid2013, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009]
+  }
+
+  public static var allMacBooks: [Device] {
+     return [.macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBook13InchMid2009, .macBook13InchEarly2009]
+  }
+
+  public static var allMacBookPros: [Device] {
+     return [.macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro13Inch2018FourThunderbolt3Ports, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .macBookProRetina15InchLate2013, .macBookProRetina15InchEarly2013, .macBookProRetina13InchLate2013, .macBookProRetina13InchEarly2013, .macBookProRetina15InchMid2012, .macBookPro15InchMid2012, .macBookProRetina13InchLate2012, .macBookPro13InchMid2012, .macBookPro17InchLate2011, .macBookPro17InchEarly2011, .macBookPro15InchLate2011, .macBookPro15InchEarly2011, .macBookPro13InchLate2011, .macBookPro13InchEarly2011, .macBookPro17InchMid2010, .macBookPro15InchMid2010, .macBookPro13InchMid2010, .macBookPro17InchMid2009, .macBookPro17InchEarly2009, .macBookPro15InchMid2009, .macBookPro15Inch253GHzMid2009, .macBookPro13InchMid2009, .macBookPro15InchLate2008, .macBookPro17InchEarly2008, .macBookPro15InchEarly2008]
+  }
+
+  public static var allIMacs: [Device] {
+     return [.iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMacRetina5K27InchLate2014, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .iMac27InchLate2009, .iMac215InchLate2009, .iMac24InchEarly2009, .iMac20InchEarly2009]
+  }
+
+  public static var allIMacPros: [Device] {
+     return [.iMacPro]
+  }
+
+  public static var allMacPros: [Device] {
+     return [.macProMid2012]
+  }
+
+  public var isMacMini: Bool {
+    return isOneOf(Device.allMacMinis)
+  }
+
+  public var isMacBookAir: Bool {
+    return isOneOf(Device.allMacBookAirs)
+  }
+
+  public var isMacBook: Bool {
+    return isOneOf(Device.allMacBooks)
+  }
+
+  public var isMacBookPro: Bool {
+    return isOneOf(Device.allMacBookPros)
+  }
+
+  public var isIMac: Bool {
+    return isOneOf(Device.allIMacs)
+  }
+
+  public var isIMacPro: Bool {
+    return isOneOf(Device.allIMacPros)
+  }
+
+  public var isMacPro: Bool {
+    return isOneOf(Device.allMacPros)
+  }
   #endif
 
   /// All real devices (i.e. all devices except for all simulators)
@@ -788,7 +1328,7 @@ public enum Device {
     #elseif os(watchOS)
       return allWatches
     #elseif os(macOS)
-      return []
+      return allMacs
     #endif
   }
 
@@ -1075,6 +1615,100 @@ extension Device: CustomStringConvertible {
       }
     #elseif os(macOS)
       switch self {
+      case .macMini2018: return "Mac mini (2018)"
+      case .macMiniLate2014: return "Mac mini (Late 2014)"
+      case .macMiniLate2012: return "Mac mini (Late 2012)"
+      case .macMiniMid2011: return "Mac mini (Mid 2011)"
+      case .macMiniMid2010: return "Mac mini (Mid 2010)"
+      case .macMiniLate2009: return "Mac mini (Late 2009)"
+      case .macMiniEarly2009: return "Mac mini (Early 2009)"
+      case .iMacRetina5K27Inch2019: return "iMac (Retina 5K, 27-inch, 2019)"
+      case .iMacRetina4K215Inch2019: return "iMac (Retina 4K, 21.5-inch, 2019)"
+      case .iMacRetina5K27Inch2017: return "iMac (Retina 5K, 27-inch, 2017)"
+      case .iMacRetina4K215Inch2017: return "iMac (Retina 4K, 21.5-inch, 2017)"
+      case .iMac215Inch2017: return "iMac (21.5-inch, 2017)"
+      case .iMacRetina5K27InchLate2015: return "iMac (Retina 5K, 27-inch, Late 2015)"
+      case .iMacRetina4K215InchLate2015: return "iMac (Retina 4K, 21.5-inch, Late 2015)"
+      case .iMac215InchLate2015: return "iMac (21.5-inch, Late 2015)"
+      case .iMacRetina5K27InchMid2015: return "iMac (Retina 5K, 27-inch, Mid 2015)"
+      case .iMacRetina5K27InchLate2014: return "iMac (Retina 5K, 27-inch, Late 2014)"
+      case .iMac215InchMid2014: return "iMac (21.5-inch, Mid 2014)"
+      case .iMac27InchLate2013: return "iMac (27-inch, Late 2013)"
+      case .iMac215InchLate2013: return "iMac (21.5-inch, Late 2013)"
+      case .iMac215InchLate2012: return "iMac (21.5-inch, Late 2012)"
+      case .iMac27InchMid2011: return "iMac (27-inch, Mid 2011)"
+      case .iMac215InchMid2011: return "iMac (21.5-inch, Mid 2011)"
+      case .iMac27InchMid2010: return "iMac (27-inch, Mid 2010)"
+      case .iMac215InchMid2010: return "iMac (21.5-inch, Mid 2010)"
+      case .iMac27InchLate2009: return "iMac (27-inch, Late 2009)"
+      case .iMac215InchLate2009: return "iMac (21.5-inch, Late 2009)"
+      case .iMac24InchEarly2009: return "iMac (24-inch, Early 2009)"
+      case .iMac20InchEarly2009: return "iMac (20-inch, Early 2009)"
+      case .macProMid2012: return "Mac Pro (Mid 2012)"
+      case .macBookRetina12Inch2017: return "MacBook (Retina, 12-inch, 2017)"
+      case .macBookRetina12InchEarly2016: return "MacBook (Retina, 12-inch, Early 2016)"
+      case .macBookRetina12InchEarly2015: return "MacBook (Retina, 12-inch, Early 2015)"
+      case .macBook13InchMid2010: return "MacBook (13-inch, Mid 2010)"
+      case .macBook13InchLate2009: return "MacBook (13-inch, Late 2009)"
+      case .macBook13InchMid2009: return "MacBook (13-inch, Mid 2009)"
+      case .macBook13InchEarly2009: return "MacBook (13-inch, Early 2009)"
+      case .macBookAirRetina13Inch2019: return "MacBook Air (Retina, 13-inch, 2019)"
+      case .macBookAirRetina13Inch2018: return "MacBook Air (Retina, 13-inch, 2018)"
+      case .macBookAir13Inch2017: return "MacBook Air (13-inch, 2017)"
+      case .macBookAir13InchEarly2015: return "MacBook Air (13-inch, Early 2015)"
+      case .macBookAir11InchEarly2015: return "MacBook Air (11-inch, Early 2015)"
+      case .macBookAir13InchEarly2014: return "MacBook Air (13-inch, Early 2014)"
+      case .macBookAir11InchEarly2014: return "MacBook Air (11-inch, Early 2014)"
+      case .macBookAir13InchMid2013: return "MacBook Air (13-inch, Mid 2013)"
+      case .macBookAir11InchMid2013: return "MacBook Air (11-inch, Mid 2013)"
+      case .macBookAir13InchMid2012: return "MacBook Air (13-inch, Mid 2012)"
+      case .macBookAir11InchMid2012: return "MacBook Air (11-inch, Mid 2012)"
+      case .macBookAir13InchMid2011: return "MacBook Air (13-inch, Mid 2011)"
+      case .macBookAir11InchMid2011: return "MacBook Air (11-inch, Mid 2011)"
+      case .macBookAir13InchLate2010: return "MacBook Air (13-inch, Late 2010)"
+      case .macBookAir11InchLate2010: return "MacBook Air (11-inch, Late 2010)"
+      case .macBookAirMid2009: return "MacBook Air (Mid 2009)"
+      case .macBookPro13Inch2019TwoThunderbolt3Ports: return "MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)"
+      case .macBookPro15Inch2019: return "MacBook Pro (15-inch, 2019)"
+      case .macBookPro13Inch2019FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)"
+      case .macBookPro15Inch2018: return "MacBook Pro (15-inch, 2018)"
+      case .macBookPro13Inch2018FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)"
+      case .macBookPro15Inch2017: return "MacBook Pro (15-inch, 2017)"
+      case .macBookPro13Inch2017FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)"
+      case .macBookPro13Inch2017TwoThunderbolt3Ports: return "MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)"
+      case .macBookPro15Inch2016: return "MacBook Pro (15-inch, 2016)"
+      case .macBookPro13Inch2016FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)"
+      case .macBookPro13Inch2016TwoThunderbolt3Ports: return "MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)"
+      case .macBookProRetina15InchMid2015: return "MacBook Pro (Retina, 15-inch, Mid 2015)"
+      case .macBookProRetina13InchEarly2015: return "MacBook Pro (Retina, 13-inch, Early 2015)"
+      case .macBookProRetina15InchMid2014: return "MacBook Pro (Retina, 15-inch, Mid 2014)"
+      case .macBookProRetina13InchMid2014: return "MacBook Pro (Retina, 13-inch, Mid 2014)"
+      case .macBookProRetina15InchLate2013: return "MacBook Pro (Retina, 15-inch, Late 2013)"
+      case .macBookProRetina15InchEarly2013: return "MacBook Pro (Retina, 15-inch, Early 2013)"
+      case .macBookProRetina13InchLate2013: return "MacBook Pro (Retina, 13-inch, Late 2013)"
+      case .macBookProRetina13InchEarly2013: return "MacBook Pro (Retina, 13-inch, Early 2013)"
+      case .macBookProRetina15InchMid2012: return "MacBook Pro (Retina, 15-inch, Mid 2012)"
+      case .macBookPro15InchMid2012: return "MacBook Pro (15-inch, Mid 2012)"
+      case .macBookProRetina13InchLate2012: return "MacBook Pro (Retina, 13-inch, Late 2012)"
+      case .macBookPro13InchMid2012: return "MacBook Pro (13-inch, Mid 2012)"
+      case .macBookPro17InchLate2011: return "MacBook Pro (17-inch, Late 2011)"
+      case .macBookPro17InchEarly2011: return "MacBook Pro (17-inch, Early 2011)"
+      case .macBookPro15InchLate2011: return "MacBook Pro (15-inch, Late 2011)"
+      case .macBookPro15InchEarly2011: return "MacBook Pro (15-inch, Early 2011)"
+      case .macBookPro13InchLate2011: return "MacBook Pro (13-inch, Late 2011)"
+      case .macBookPro13InchEarly2011: return "MacBook Pro (13-inch, Early 2011)"
+      case .macBookPro17InchMid2010: return "MacBook Pro (17-inch, Mid 2010)"
+      case .macBookPro15InchMid2010: return "MacBook Pro (15-inch, Mid 2010)"
+      case .macBookPro13InchMid2010: return "MacBook Pro (13-inch, Mid 2010)"
+      case .macBookPro17InchMid2009: return "MacBook Pro (17-inch, Mid 2009)"
+      case .macBookPro17InchEarly2009: return "MacBook Pro (17-inch, Early 2009)"
+      case .macBookPro15InchMid2009: return "MacBook Pro (15-inch, Mid 2009)"
+      case .macBookPro15Inch253GHzMid2009: return "MacBook Pro (15-inch, 2.53GHz, Mid 2009)"
+      case .macBookPro13InchMid2009: return "MacBook Pro (13-inch, Mid 2009)"
+      case .macBookPro15InchLate2008: return "MacBook Pro (15-inch, Late 2008)"
+      case .macBookPro17InchEarly2008: return "MacBook Pro (17-inch, Early 2008)"
+      case .macBookPro15InchEarly2008: return "MacBook Pro (15-inch, Early 2008)"
+      case .iMacPro: return "iMac Pro (2017)"
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier
       }
@@ -1456,5 +2090,27 @@ extension Device {
     return self.cameras.contains(.ultraWide)
   }
 
+}
+#endif
+
+#if os(macOS)
+private func sysctlData(for keys: [Int32]) throws -> [Int8] {
+    return try keys.withUnsafeBufferPointer { keysPointer -> [Int8] in
+        // Get the data size
+        var requiredSize = 0
+        var result = Darwin.sysctl(UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress), UInt32(keys.count), nil, &requiredSize, nil, 0)
+        if result != 0, let code = POSIXErrorCode(rawValue: errno) {
+            throw POSIXError(code)
+        }
+        // get info
+        let data = [Int8](repeating: 0, count: requiredSize)
+        result = data.withUnsafeBufferPointer { dataBuffer -> Int32 in
+            Darwin.sysctl(UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress), UInt32(keys.count), UnsafeMutableRawPointer(mutating: dataBuffer.baseAddress), &requiredSize, nil, 0)
+        }
+        if result != 0, let code = POSIXErrorCode(rawValue: errno) {
+            throw POSIXError(code)
+        }
+        return data
+    }
 }
 #endif

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -520,7 +520,7 @@ public enum Device {
     /// Device is an [iMac Pro](https://support.apple.com/kb/SP771)
     ///
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP771/SP771-imac-pro-2017.png)
-    case iMacPro
+    case iMacPro2017
   #endif
 
   /// Device is [Simulator](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/iOS_Simulator_Guide/Introduction/Introduction.html)
@@ -697,7 +697,7 @@ public enum Device {
       case "MacBookPro12,1": return macBookProRetina13InchEarly2015
       case "MacBookPro11,2": return macBookProRetina15InchMid2014
       case "MacBookPro11,1": return macBookProRetina13InchMid2014
-      case "iMacPro1,1": return iMacPro
+      case "iMacPro1,1": return iMacPro2017
       default: return unknown(identifier)
       }
     #endif
@@ -1079,7 +1079,7 @@ public enum Device {
   #elseif os(macOS)
   /// All Macs
   public static var allMacs: [Device] {
-     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .iMacPro]
+     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .iMacPro2017]
   }
 
   public static var allMacMinis: [Device] {
@@ -1103,7 +1103,7 @@ public enum Device {
   }
 
   public static var allIMacPros: [Device] {
-     return [.iMacPro]
+     return [.iMacPro2017]
   }
 
   public static var allMacPros: [Device] {
@@ -1494,7 +1494,7 @@ extension Device: CustomStringConvertible {
       case .macBookProRetina13InchEarly2015: return "MacBook Pro (Retina, 13-inch, Early 2015)"
       case .macBookProRetina15InchMid2014: return "MacBook Pro (Retina, 15-inch, Mid 2014)"
       case .macBookProRetina13InchMid2014: return "MacBook Pro (Retina, 13-inch, Mid 2014)"
-      case .iMacPro: return "iMac Pro (2017)"
+      case .iMacPro2017: return "iMac Pro (2017)"
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier
       }

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -381,10 +381,22 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg)
     case iMac215InchMid2010
+    /// Device is a [Mac Pro (2019)](https://support.apple.com/kb/SP797)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2019.jpg)
+    case macPro2019
+    /// Device is a [Mac Pro (Late 2013)](https://support.apple.com/kb/SP697)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2013.jpg)
+    case macProLate2013
     /// Device is a [Mac Pro (Mid 2012)](https://support.apple.com/kb/SP652)
     ///
-    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/macpro_previous.png)
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2009-2012.jpg)
     case macProMid2012
+    /// Device is a [Mac Pro (Early 2009)](https://support.apple.com/kb/SP506)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2009-2012.jpg)
+    case macProEarly2009
     /// Device is a [MacBook (Retina, 12-inch, 2017)](https://support.apple.com/kb/SP757)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2017-device.jpg)
@@ -667,7 +679,10 @@ public enum Device {
       case "iMac12,1": return iMac215InchMid2011
       case "iMac11,3": return iMac27InchMid2010
       case "iMac11,2": return iMac215InchMid2010
+      case "MacPro7,1": return macPro2019
+      case "MacPro6,1": return macProLate2013
       case "MacPro5,1": return macProMid2012
+      case "MacPro4,1": return macProEarly2009
       case "MacBook10,1": return macBookRetina12Inch2017
       case "MacBook9,1": return macBookRetina12InchEarly2016
       case "MacBook8,1": return macBookRetina12InchEarly2015
@@ -1084,7 +1099,7 @@ public enum Device {
   #elseif os(macOS)
   /// All Macs
   public static var allMacs: [Device] {
-     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro16Inch2019, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .iMacPro2017]
+     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .macPro2019, .macProLate2013, .macProMid2012, .macProEarly2009, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro16Inch2019, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .iMacPro2017]
   }
 
   public static var allMacMinis: [Device] {
@@ -1112,7 +1127,7 @@ public enum Device {
   }
 
   public static var allMacPros: [Device] {
-     return [.macProMid2012]
+     return [.macPro2019, .macProLate2013, .macProMid2012, .macProEarly2009]
   }
 
   public var isMacMini: Bool {
@@ -1465,7 +1480,10 @@ extension Device: CustomStringConvertible {
       case .iMac215InchMid2011: return "iMac (21.5-inch, Mid 2011)"
       case .iMac27InchMid2010: return "iMac (27-inch, Mid 2010)"
       case .iMac215InchMid2010: return "iMac (21.5-inch, Mid 2010)"
-      case .macProMid2012: return "Mac Pro (Mid 2012)"
+      case .macPro2019: return "Mac Pro (2019)"
+      case .macProLate2013: return "Mac Pro (Late 2013)"
+      case .macProMid2012: return "Mac Pro (Mid 2010 to Mid 2012)"
+      case .macProEarly2009: return "Mac Pro (Early 2009)"
       case .macBookRetina12Inch2017: return "MacBook (Retina, 12-inch, 2017)"
       case .macBookRetina12InchEarly2016: return "MacBook (Retina, 12-inch, Early 2016)"
       case .macBookRetina12InchEarly2015: return "MacBook (Retina, 12-inch, Early 2015)"

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -461,6 +461,10 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg)
     case macBookAirMid2009
+    /// Device is a [MacBook Pro (16-inch, 2019)](https://support.apple.com/kb/SP809)
+    ///
+    /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-16in-2019.jpg)
+    case macBookPro16Inch2019
     /// Device is a [MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP799)
     ///
     /// ![Image](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg)
@@ -683,6 +687,7 @@ public enum Device {
       case "MacBookAir3,2": return macBookAir13InchLate2010
       case "MacBookAir3,1": return macBookAir11InchLate2010
       case "MacBookAir2,1": return macBookAirMid2009
+      case "MacBookPro16,1": return macBookPro16Inch2019
       case "MacBookPro15,4": return macBookPro13Inch2019TwoThunderbolt3Ports
       case "MacBookPro15,3": return macBookPro15Inch2019
       case "MacBookPro15,2": return macBookPro13Inch2019FourThunderbolt3Ports
@@ -1079,7 +1084,7 @@ public enum Device {
   #elseif os(macOS)
   /// All Macs
   public static var allMacs: [Device] {
-     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .iMacPro2017]
+     return [.macMini2018, .macMiniLate2014, .macMiniLate2012, .macMiniMid2011, .macMiniMid2010, .macMini2009, .iMacRetina5K27Inch2019, .iMacRetina4K215Inch2019, .iMacRetina5K27Inch2017, .iMacRetina4K215Inch2017, .iMac215Inch2017, .iMacRetina5K27InchLate2015, .iMacRetina4K215InchLate2015, .iMac215InchLate2015, .iMacRetina5K27InchMid2015, .iMac215InchMid2014, .iMac27InchLate2013, .iMac215InchLate2013, .iMac215InchLate2012, .iMac27InchMid2011, .iMac215InchMid2011, .iMac27InchMid2010, .iMac215InchMid2010, .macProMid2012, .macBookRetina12Inch2017, .macBookRetina12InchEarly2016, .macBookRetina12InchEarly2015, .macBook13InchMid2010, .macBook13InchLate2009, .macBookAirRetina13Inch2019, .macBookAirRetina13Inch2018, .macBookAir13Inch2017, .macBookAir13InchEarly2015, .macBookAir11InchEarly2015, .macBookAir13InchEarly2014, .macBookAir11InchEarly2014, .macBookAir13InchMid2012, .macBookAir11InchMid2012, .macBookAir13InchMid2011, .macBookAir11InchMid2011, .macBookAir13InchLate2010, .macBookAir11InchLate2010, .macBookAirMid2009, .macBookPro16Inch2019, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014, .iMacPro2017]
   }
 
   public static var allMacMinis: [Device] {
@@ -1095,7 +1100,7 @@ public enum Device {
   }
 
   public static var allMacBookPros: [Device] {
-     return [.macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014]
+     return [.macBookPro16Inch2019, .macBookPro13Inch2019TwoThunderbolt3Ports, .macBookPro15Inch2019, .macBookPro13Inch2019FourThunderbolt3Ports, .macBookPro15Inch2018, .macBookPro15Inch2017, .macBookPro13Inch2017FourThunderbolt3Ports, .macBookPro13Inch2017TwoThunderbolt3Ports, .macBookPro15Inch2016, .macBookPro13Inch2016FourThunderbolt3Ports, .macBookPro13Inch2016TwoThunderbolt3Ports, .macBookProRetina15InchMid2015, .macBookProRetina13InchEarly2015, .macBookProRetina15InchMid2014, .macBookProRetina13InchMid2014]
   }
 
   public static var allIMacs: [Device] {
@@ -1480,6 +1485,7 @@ extension Device: CustomStringConvertible {
       case .macBookAir13InchLate2010: return "MacBook Air (13-inch, Late 2010)"
       case .macBookAir11InchLate2010: return "MacBook Air (11-inch, Late 2010)"
       case .macBookAirMid2009: return "MacBook Air (Mid 2009)"
+      case .macBookPro16Inch2019: return "MacBook Pro (16-inch, 2019)"
       case .macBookPro13Inch2019TwoThunderbolt3Ports: return "MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)"
       case .macBookPro15Inch2019: return "MacBook Pro (15-inch, 2019)"
       case .macBookPro13Inch2019FourThunderbolt3Ports: return "MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)"

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -177,32 +177,32 @@ macMinis = [
             "macMini2018",
             "Device is a [Mac mini (2018)](https://support.apple.com/kb/SP782)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2018-space-gray.jpg",
-            ["Macmini8,1"], 0,(), "Mac mini (2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["Macmini8,1"], 0, (), "Mac mini (2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macMiniLate2014",
             "Device is a [Mac mini (Late 2014)](https://support.apple.com/kb/SP710)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2014.jpg",
-            ["Macmini7,1"], 0,(), "Mac mini (Late 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["Macmini7,1"], 0, (), "Mac mini (Late 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macMiniLate2012",
             "Device is a [Mac mini (Late 2012)](https://support.apple.com/kb/SP659)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg",
-            ["Macmini6,1", "Macmini6,2"], 0,(), "Mac mini (Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["Macmini6,1", "Macmini6,2"], 0, (), "Mac mini (Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macMiniMid2011",
             "Device is a [Mac mini (Mid 2011)](https://support.apple.com/kb/SP632)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg",
-            ["Macmini5,1", "Macmini5,2"], 0,(), "Mac mini (Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["Macmini5,1", "Macmini5,2"], 0, (), "Mac mini (Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macMiniMid2010",
             "Device is a [Mac mini (Mid 2010)](https://support.apple.com/kb/SP585)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2010-device.jpg",
-            ["Macmini4,1"], 0,(), "Mac mini (Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["Macmini4,1"], 0, (), "Mac mini (Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macMini2009",
             "Device is a [Mac mini (Late 2009)](https://support.apple.com/kb/SP577) or [Mac mini (Early 2009)](https://support.apple.com/kb/SP505)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg",
-            ["Macmini3,1"], 0,(), "Mac mini (2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["Macmini3,1"], 0, (), "Mac mini (2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/imac, https://support.apple.com/en-us/HT201634
 iMacs = [
@@ -210,87 +210,87 @@ iMacs = [
             "iMacRetina5K27Inch2019",
             "Device is a [iMac (Retina 5K, 27-inch, 2019)](https://support.apple.com/kb/SP790)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
-            ["iMac19,1"], 0,(), "iMac (Retina 5K, 27-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac19,1"], 0, (), "iMac (Retina 5K, 27-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina4K215Inch2019",
             "Device is a [iMac (Retina 4K, 21.5-inch, 2019)](https://support.apple.com/kb/SP789)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg",
-            ["iMac19,2"], 0,(), "iMac (Retina 4K, 21.5-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac19,2"], 0, (), "iMac (Retina 4K, 21.5-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina5K27Inch2017",
             "Device is a [iMac (Retina 5K, 27-inch, 2017)](https://support.apple.com/kb/SP760)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
-            ["iMac18,3"], 0,(), "iMac (Retina 5K, 27-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac18,3"], 0, (), "iMac (Retina 5K, 27-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina4K215Inch2017",
             "Device is a [iMac (Retina 4K, 21.5-inch, 2017)](https://support.apple.com/kb/SP759)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg",
-            ["iMac18,2"], 0,(), "iMac (Retina 4K, 21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac18,2"], 0, (), "iMac (Retina 4K, 21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215Inch2017",
             "Device is a [iMac (21.5-inch, 2017)](https://support.apple.com/kb/SP758)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg",
-            ["iMac18,1"], 0,(), "iMac (21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac18,1"], 0, (), "iMac (21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina5K27InchLate2015",
             "Device is a [iMac (Retina 5K, 27-inch, Late 2015)](https://support.apple.com/kb/SP731)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
-            ["iMac17,1"], 0,(), "iMac (Retina 5K, 27-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac17,1"], 0, (), "iMac (Retina 5K, 27-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina4K215InchLate2015",
             "Device is a [iMac (Retina 4K, 21.5-inch, Late 2015)](https://support.apple.com/kb/SP732)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2015.jpg",
-            ["iMac16,2"], 0,(), "iMac (Retina 4K, 21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac16,2"], 0, (), "iMac (Retina 4K, 21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchLate2015",
             "Device is a [iMac (21.5-inch, Late 2015)](https://support.apple.com/kb/SP733)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2015.jpg",
-            ["iMac16,1"], 0,(), "iMac (21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac16,1"], 0, (), "iMac (21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina5K27InchMid2015",
             "Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718) or [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
-            ["iMac15,1"], 0,(), "iMac (Retina 5K, 27-inch)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac15,1"], 0, (), "iMac (Retina 5K, 27-inch)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchMid2014",
             "Device is a [iMac (21.5-inch, Mid 2014)](https://support.apple.com/kb/SP701)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg",
-            ["iMac14,4"], 0,(), "iMac (21.5-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac14,4"], 0, (), "iMac (21.5-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac27InchLate2013",
             "Device is a [iMac (27-inch, Late 2013)](https://support.apple.com/kb/SP688)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2013.jpg",
-            ["iMac14,2"], 0,(), "iMac (27-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac14,2"], 0, (), "iMac (27-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchLate2013",
             "Device is a [iMac (21.5-inch, Late 2013)](https://support.apple.com/kb/SP687)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2013.jpg",
-            ["iMac14,1"], 0,(), "iMac (21.5-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac14,1"], 0, (), "iMac (21.5-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchLate2012",
             "Device is a [iMac (21.5-inch, Late 2012)](https://support.apple.com/kb/SP665)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2012.jpg",
-            ["iMac13,1"], 0,(), "iMac (21.5-inch, Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac13,1"], 0, (), "iMac (21.5-inch, Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac27InchMid2011",
             "Device is a [iMac (27-inch, Mid 2011)](https://support.apple.com/kb/SP689)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2011.jpg",
-            ["iMac12,2"], 0,(), "iMac (27-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac12,2"], 0, (), "iMac (27-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchMid2011",
             "Device is a [iMac (21.5-inch, Mid 2011)](https://support.apple.com/kb/SP623)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2011.jpg",
-            ["iMac12,1"], 0,(), "iMac (21.5-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac12,1"], 0, (), "iMac (21.5-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac27InchMid2010",
             "Device is a [iMac (27-inch, Mid 2010)](https://support.apple.com/kb/SP695)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg",
-            ["iMac11,3"], 0,(), "iMac (27-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac11,3"], 0, (), "iMac (27-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchMid2010",
             "Device is a [iMac (21.5-inch, Mid 2010)](https://support.apple.com/kb/SP588)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg",
-            ["iMac11,2"], 0,(), "iMac (21.5-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["iMac11,2"], 0, (), "iMac (21.5-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/mac-pro, https://support.apple.com/en-us/HT202888
 macPros = [
@@ -298,7 +298,7 @@ macPros = [
             "macProMid2012",
             "Device is a [Mac Pro (Mid 2012)](https://support.apple.com/kb/SP652)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/macpro_previous.png",
-            ["MacPro5,1"], 0,(), "Mac Pro (Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["MacPro5,1"], 0, (), "Mac Pro (Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/macbook, https://support.apple.com/en-us/HT201608
 macBooks = [
@@ -306,27 +306,27 @@ macBooks = [
             "macBookRetina12Inch2017",
             "Device is a [MacBook (Retina, 12-inch, 2017)](https://support.apple.com/kb/SP757)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2017-device.jpg",
-            ["MacBook10,1"], 0,(), "MacBook (Retina, 12-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBook10,1"], 0, (), "MacBook (Retina, 12-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookRetina12InchEarly2016",
             "Device is a [MacBook (Retina, 12-inch, Early 2016)](https://support.apple.com/kb/SP741)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2016-device.jpg",
-            ["MacBook9,1"], 0,(), "MacBook (Retina, 12-inch, Early 2016)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBook9,1"], 0, (), "MacBook (Retina, 12-inch, Early 2016)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookRetina12InchEarly2015",
             "Device is a [MacBook (Retina, 12-inch, Early 2015)](https://support.apple.com/kb/SP712)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2015-device.jpg",
-            ["MacBook8,1"], 0,(), "MacBook (Retina, 12-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBook8,1"], 0, (), "MacBook (Retina, 12-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBook13InchMid2010",
             "Device is a [MacBook (13-inch, Mid 2010)](https://support.apple.com/kb/SP584)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
-            ["MacBook7,1"], 0,(), "MacBook (13-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBook7,1"], 0, (), "MacBook (13-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBook13InchLate2009",
             "Device is a [MacBook (13-inch, Late 2009)](https://support.apple.com/kb/SP579)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
-            ["MacBook6,1"], 0,(), "MacBook (13-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["MacBook6,1"], 0, (), "MacBook (13-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/macbook-air, https://support.apple.com/en-us/HT201862
 macBookAirs = [
@@ -334,72 +334,72 @@ macBookAirs = [
             "macBookAirRetina13Inch2019",
             "Device is a [MacBook Air (Retina, 13-inch, 2019)](https://support.apple.com/kb/SP798)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2018-device.jpg",
-            ["MacBookAir8,2"], 0,(), "MacBook Air (Retina, 13-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir8,2"], 0, (), "MacBook Air (Retina, 13-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAirRetina13Inch2018",
             "Device is a [MacBook Air (Retina, 13-inch, 2018)](https://support.apple.com/kb/SP783)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2018-device.jpg",
-            ["MacBookAir8,1"], 0,(), "MacBook Air (Retina, 13-inch, 2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir8,1"], 0, (), "MacBook Air (Retina, 13-inch, 2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13Inch2017",
             "Device is a [MacBook Air (13-inch, 2017)](https://support.apple.com/kb/SP753)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2017-device.jpg",
-            ["MacBookAir7,3"], 0,(), "MacBook Air (13-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir7,3"], 0, (), "MacBook Air (13-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchEarly2015",
             "Device is a [MacBook Air (13-inch, Early 2015)](https://support.apple.com/kb/SP714)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg",
-            ["MacBookAir7,2"], 0,(), "MacBook Air (13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir7,2"], 0, (), "MacBook Air (13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir11InchEarly2015",
             "Device is a [MacBook Air (11-inch, Early 2015)](https://support.apple.com/kb/SP713)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-11in-device.jpg",
-            ["MacBookAir7,1"], 0,(), "MacBook Air (11-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir7,1"], 0, (), "MacBook Air (11-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchEarly2014",
             "Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700) or [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
-            ["MacBookAir6,2"], 0,(), "MacBook Air (13-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir6,2"], 0, (), "MacBook Air (13-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir11InchEarly2014",
             "Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699) or [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-11in-device.jpg",
-            ["MacBookAir6,1"], 0,(), "MacBook Air (11-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir6,1"], 0, (), "MacBook Air (11-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchMid2012",
             "Device is a [MacBook Air (13-inch, Mid 2012)](https://support.apple.com/kb/SP670)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg",
-            ["MacBookAir5,2"], 0,(), "MacBook Air (13-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir5,2"], 0, (), "MacBook Air (13-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir11InchMid2012",
             "Device is a [MacBook Air (11-inch, Mid 2012)](https://support.apple.com/kb/SP650)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-11in-device.jpg",
-            ["MacBookAir5,1"], 0,(), "MacBook Air (11-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir5,1"], 0, (), "MacBook Air (11-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchMid2011",
             "Device is a [MacBook Air (13-inch, Mid 2011)](https://support.apple.com/kb/SP683)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-13in-device.jpg",
-            ["MacBookAir4,2"], 0,(), "MacBook Air (13-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir4,2"], 0, (), "MacBook Air (13-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir11InchMid2011",
             "Device is a [MacBook Air (11-inch, Mid 2011)](https://support.apple.com/kb/SP631)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-11in-device.jpg",
-            ["MacBookAir4,1"], 0,(), "MacBook Air (11-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir4,1"], 0, (), "MacBook Air (11-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchLate2010",
             "Device is a [MacBook Air (13-inch, Late 2010)](https://support.apple.com/kb/SP618)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg",
-            ["MacBookAir3,2"], 0,(), "MacBook Air (13-inch, Late 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir3,2"], 0, (), "MacBook Air (13-inch, Late 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir11InchLate2010",
             "Device is a [MacBook Air (11-inch, Late 2010)](https://support.apple.com/kb/SP617)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2010-11in-device.jpg",
-            ["MacBookAir3,1"], 0,(), "MacBook Air (11-inch, Late 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir3,1"], 0, (), "MacBook Air (11-inch, Late 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAirMid2009",
             "Device is a [MacBook Air (Mid 2009)](https://support.apple.com/kb/SP548)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg",
-            ["MacBookAir2,1"], 0,(), "MacBook Air (Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["MacBookAir2,1"], 0, (), "MacBook Air (Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/macbook-pro, https://support.apple.com/en-us/HT201300
 macBookPros = [
@@ -407,77 +407,77 @@ macBookPros = [
             "macBookPro16Inch2019",
             "Device is a [MacBook Pro (16-inch, 2019)](https://support.apple.com/kb/SP809)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-16in-2019.jpg",
-            ["MacBookPro16,1"], 0,(), "MacBook Pro (16-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro16,1"], 0, (), "MacBook Pro (16-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2019TwoThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP799)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
-            ["MacBookPro15,4"], 0,(), "MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro15,4"], 0, (), "MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro15Inch2019",
             "Device is a [MacBook Pro (15-inch, 2019)](https://support.apple.com/kb/SP794)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg",
-            ["MacBookPro15,3"], 0,(), "MacBook Pro (15-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro15,3"], 0, (), "MacBook Pro (15-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2019FourThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795) or [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
-            ["MacBookPro15,2"], 0,(), "MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro15,2"], 0, (), "MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro15Inch2018",
             "Device is a [MacBook Pro (15-inch, 2018)](https://support.apple.com/kb/SP776)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg",
-            ["MacBookPro15,1"], 0,(), "MacBook Pro (15-inch, 2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro15,1"], 0, (), "MacBook Pro (15-inch, 2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro15Inch2017",
             "Device is a [MacBook Pro (15-inch, 2017)](https://support.apple.com/kb/SP756)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg",
-            ["MacBookPro14,3"], 0,(), "MacBook Pro (15-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro14,3"], 0, (), "MacBook Pro (15-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2017FourThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP755)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-13in-device.jpg",
-            ["MacBookPro14,2"], 0,(), "MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro14,2"], 0, (), "MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2017TwoThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP754)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-13in-device-2thunderbolt-3ports.jpg",
-            ["MacBookPro14,1"], 0,(), "MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro14,1"], 0, (), "MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro15Inch2016",
             "Device is a [MacBook Pro (15-inch, 2016)](https://support.apple.com/kb/SP749)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg",
-            ["MacBookPro13,3"], 0,(), "MacBook Pro (15-inch, 2016)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro13,3"], 0, (), "MacBook Pro (15-inch, 2016)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2016FourThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP748)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-13in-device.jpg",
-            ["MacBookPro13,2"], 0,(), "MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro13,2"], 0, (), "MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2016TwoThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP747)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-13in-device.jpg",
-            ["MacBookPro13,1"], 0,(), "MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro13,1"], 0, (), "MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina15InchMid2015",
             "Device is a [MacBook Pro (Retina, 15-inch, Mid 2015)](https://support.apple.com/kb/SP719)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg",
-            ["MacBookPro11,4"], 0,(), "MacBook Pro (Retina, 15-inch, Mid 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro11,4"], 0, (), "MacBook Pro (Retina, 15-inch, Mid 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina13InchEarly2015",
             "Device is a [MacBook Pro (Retina, 13-inch, Early 2015)](https://support.apple.com/kb/SP715)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-2015-13in-device.jpg",
-            ["MacBookPro12,1"], 0,(), "MacBook Pro (Retina, 13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro12,1"], 0, (), "MacBook Pro (Retina, 13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina15InchMid2014",
             "Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704) or [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg",
-            ["MacBookPro11,2"], 0,(), "MacBook Pro (Retina, 15-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro11,2"], 0, (), "MacBook Pro (Retina, 15-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina13InchMid2014",
             "Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703) or [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-13in-device.jpg",
-            ["MacBookPro11,1"], 0,(), "MacBook Pro (Retina, 13-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["MacBookPro11,1"], 0, (), "MacBook Pro (Retina, 13-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/imac-pro
 iMacPros = [
@@ -485,7 +485,7 @@ iMacPros = [
             "iMacPro2017",
             "Device is an [iMac Pro](https://support.apple.com/kb/SP771)",
             "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP771/SP771-imac-pro-2017.png",
-            ["iMacPro1,1"], 0,(), "iMac Pro (2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["iMacPro1,1"], 0, (), "iMac Pro (2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 
 iOSDevices = iPods + iPhones + iPads + homePods
@@ -673,7 +673,7 @@ public enum Device {
       case .unknown: return -1
       }
     #elseif os(macOS)
-    return -1
+      return -1
     #endif
   }
   #endif

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -170,13 +170,18 @@ watches = [
             "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP808/sp808-apple-watch-series-5_2x.png",
             ["Watch5,2", "Watch5,4"], 2.0, (4,5), "Apple Watch Series 5 44mm", 326, False, False, False, False, False, False, False, True, False, 0, True, 0)
   ]
+# macOS
+macs = []
 
 iOSDevices = iPods + iPhones + iPads + homePods
 tvOSDevices = tvs
 watchOSDevices = watches
+macOSDevices = macs
 }%
 #if os(watchOS)
 import WatchKit
+#elseif os(macOS)
+import AppKit
 #else
 import UIKit
 #endif
@@ -229,6 +234,13 @@ public enum Device {
 % end
   #elseif os(watchOS)
 % for device in watchOSDevices:
+    /// ${device.comment}
+    ///
+    /// ![Image](${device.imageURL})
+    case ${device.caseName}
+% end
+  #elseif os(macOS)
+% for device in macOSDevices:
     /// ${device.comment}
     ///
     /// ![Image](${device.imageURL})
@@ -294,6 +306,8 @@ public enum Device {
       case "i386", "x86_64": return simulator(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "watchOS"))
       default: return unknown(identifier)
       }
+    #elseif os(macOS)
+    return unknown(identifier)
     #endif
   }
 
@@ -331,6 +345,8 @@ public enum Device {
       case .simulator(let model): return model.diagonal
       case .unknown: return -1
       }
+    #elseif os(macOS)
+    return -1
     #endif
   }
   #endif
@@ -354,6 +370,8 @@ public enum Device {
       case .unknown: return (width: -1, height: -1)
       }
     #elseif os(tvOS)
+      return (width: -1, height: -1)
+    #elseif os(macOS)
       return (width: -1, height: -1)
     #endif
   }
@@ -574,6 +592,8 @@ public enum Device {
       return allTVs
     #elseif os(watchOS)
       return allWatches
+    #elseif os(macOS)
+      return []
     #endif
   }
 
@@ -625,6 +645,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().name
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.name
     #endif
@@ -635,6 +657,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.systemName
     #endif
@@ -645,6 +669,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().systemVersion
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.systemVersion
     #endif
@@ -655,6 +681,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().model
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.model
     #endif
@@ -665,6 +693,8 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().localizedModel
+    #elseif os(macOS)
+    return nil
     #else
     return UIDevice.current.localizedModel
     #endif
@@ -689,6 +719,8 @@ public enum Device {
     case .unknown: return nil
     }
     #elseif os(tvOS)
+    return nil
+    #elseif os(macOS)
     return nil
     #endif
   }
@@ -742,6 +774,11 @@ extension Device: CustomStringConvertible {
 % for device in tvOSDevices:
       case .${device.caseName}: return "${device.description}"
 % end
+      case .simulator(let model): return "Simulator (\(model))"
+      case .unknown(let identifier): return identifier
+      }
+    #elseif os(macOS)
+      switch self {
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier
       }

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -295,10 +295,25 @@ iMacs = [
 ## https://support.apple.com/mac/mac-pro, https://support.apple.com/en-us/HT202888
 macPros = [
             Device(
+            "macPro2019",
+            "Device is a [Mac Pro (2019)](https://support.apple.com/kb/SP797)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2019.jpg",
+            ["MacPro7,1"], 0, (), "Mac Pro (2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macProLate2013",
+            "Device is a [Mac Pro (Late 2013)](https://support.apple.com/kb/SP697)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2013.jpg",
+            ["MacPro6,1"], 0, (), "Mac Pro (Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
             "macProMid2012",
             "Device is a [Mac Pro (Mid 2012)](https://support.apple.com/kb/SP652)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/macpro_previous.png",
-            ["MacPro5,1"], 0, (), "Mac Pro (Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2009-2012.jpg",
+            ["MacPro5,1"], 0, (), "Mac Pro (Mid 2010 to Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macProEarly2009",
+            "Device is a [Mac Pro (Early 2009)](https://support.apple.com/kb/SP506)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/id-mac-pro-2009-2012.jpg",
+            ["MacPro4,1"], 0, (), "Mac Pro (Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/macbook, https://support.apple.com/en-us/HT201608
 macBooks = [

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -171,12 +171,501 @@ watches = [
             ["Watch5,2", "Watch5,4"], 2.0, (4,5), "Apple Watch Series 5 44mm", 326, False, False, False, False, False, False, False, True, False, 0, True, 0)
   ]
 # macOS
-macs = []
+macMinis = [
+            Device(
+            "macMini2018",
+            "Device is a [Mac mini (2018)](https://support.apple.com/kb/SP782)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2018-space-gray.jpg",
+            ["Macmini8,1"], 0,(), "Mac mini (2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macMiniLate2014",
+            "Device is a [Mac mini (Late 2014)](https://support.apple.com/kb/SP710)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2014.jpg",
+            ["Macmini7,1"], 0,(), "Mac mini (Late 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macMiniLate2012",
+            "Device is a [Mac mini (Late 2012)](https://support.apple.com/kb/SP659)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg",
+            ["Macmini6,1" ," Macmini6,2"], 0,(), "Mac mini (Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macMiniMid2011",
+            "Device is a [Mac mini (Mid 2011)](https://support.apple.com/kb/SP632)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg",
+            ["Macmini5,1" ," Macmini5,2"], 0,(), "Mac mini (Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macMiniMid2010",
+            "Device is a [Mac mini (Mid 2010)](https://support.apple.com/kb/SP585)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2010-device.jpg",
+            ["Macmini4,1"], 0,(), "Mac mini (Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macMiniLate2009",
+            "Device is a [Mac mini (Late 2009)](https://support.apple.com/kb/SP577)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg",
+            ["Macmini3,1"], 0,(), "Mac mini (Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macMiniEarly2009",
+            "Device is a [Mac mini (Early 2009)](https://support.apple.com/kb/SP505)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg",
+            ["Macmini3,1"], 0,(), "Mac mini (Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+]
+## https://support.apple.com/mac/imac, https://support.apple.com/en-us/HT201634
+iMacs = [
+            Device(
+            "iMacRetina5K27Inch2019",
+            "Device is a [iMac (Retina 5K, 27-inch, 2019)](https://support.apple.com/kb/SP790)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            ["iMac19,1"], 0,(), "iMac (Retina 5K, 27-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMacRetina4K215Inch2019",
+            "Device is a [iMac (Retina 4K, 21.5-inch, 2019)](https://support.apple.com/kb/SP789)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            ["iMac19,2"], 0,(), "iMac (Retina 4K, 21.5-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMacRetina5K27Inch2017",
+            "Device is a [iMac (Retina 5K, 27-inch, 2017)](https://support.apple.com/kb/SP760)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            ["iMac18,3"], 0,(), "iMac (Retina 5K, 27-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMacRetina4K215Inch2017",
+            "Device is a [iMac (Retina 4K, 21.5-inch, 2017)](https://support.apple.com/kb/SP759)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            ["iMac18,2"], 0,(), "iMac (Retina 4K, 21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215Inch2017",
+            "Device is a [iMac (21.5-inch, 2017)](https://support.apple.com/kb/SP758)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            ["iMac18,1"], 0,(), "iMac (21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMacRetina5K27InchLate2015",
+            "Device is a [iMac (Retina 5K, 27-inch, Late 2015)](https://support.apple.com/kb/SP731)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
+            ["iMac17,1"], 0,(), "iMac (Retina 5K, 27-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMacRetina4K215InchLate2015",
+            "Device is a [iMac (Retina 4K, 21.5-inch, Late 2015)](https://support.apple.com/kb/SP732)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
+            ["iMac16,2"], 0,(), "iMac (Retina 4K, 21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215InchLate2015",
+            "Device is a [iMac (21.5-inch, Late 2015)](https://support.apple.com/kb/SP733)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
+            ["iMac16,1"], 0,(), "iMac (21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMacRetina5K27InchMid2015",
+            "Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
+            ["iMac15,1"], 0,(), "iMac (Retina 5K, 27-inch, Mid 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMacRetina5K27InchLate2014",
+            "Device is a [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg",
+            ["iMac15,1"], 0,(), "iMac (Retina 5K, 27-inch, Late 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215InchMid2014",
+            "Device is a [iMac (21.5-inch, Mid 2014)](https://support.apple.com/kb/SP701)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg",
+            ["iMac14,4"], 0,(), "iMac (21.5-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac27InchLate2013",
+            "Device is a [iMac (27-inch, Late 2013)](https://support.apple.com/kb/SP688)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2013.jpg",
+            ["iMac14,2"], 0,(), "iMac (27-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215InchLate2013",
+            "Device is a [iMac (21.5-inch, Late 2013)](https://support.apple.com/kb/SP687)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2013.jpg",
+            ["iMac14,1"], 0,(), "iMac (21.5-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215InchLate2012",
+            "Device is a [iMac (21.5-inch, Late 2012)](https://support.apple.com/kb/SP665)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2012.jpg",
+            ["iMac13,1"], 0,(), "iMac (21.5-inch, Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac27InchMid2011",
+            "Device is a [iMac (27-inch, Mid 2011)](https://support.apple.com/kb/SP689)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2011.jpg",
+            ["iMac12,2"], 0,(), "iMac (27-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215InchMid2011",
+            "Device is a [iMac (21.5-inch, Mid 2011)](https://support.apple.com/kb/SP623)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2011.jpg",
+            ["iMac12,1"], 0,(), "iMac (21.5-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac27InchMid2010",
+            "Device is a [iMac (27-inch, Mid 2010)](https://support.apple.com/kb/SP695)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg",
+            ["iMac11,3"], 0,(), "iMac (27-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215InchMid2010",
+            "Device is a [iMac (21.5-inch, Mid 2010)](https://support.apple.com/kb/SP588)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg",
+            ["iMac11,2"], 0,(), "iMac (21.5-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac27InchLate2009",
+            "Device is a [iMac (27-inch, Late 2009)](https://support.apple.com/kb/SP696)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
+            ["iMac10,1"], 0,(), "iMac (27-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac215InchLate2009",
+            "Device is a [iMac (21.5-inch, Late 2009)](https://support.apple.com/kb/SP576)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
+            ["iMac10,1"], 0,(), "iMac (21.5-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac24InchEarly2009",
+            "Device is a [iMac (24-inch, Early 2009)](https://support.apple.com/kb/SP507)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
+            ["iMac9,1"], 0,(), "iMac (24-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "iMac20InchEarly2009",
+            "Device is a [iMac (20-inch, Early 2009)](https://support.apple.com/kb/SP507)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
+            ["iMac9,1"], 0,(), "iMac (20-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+]
+## https://support.apple.com/mac/mac-pro, https://support.apple.com/en-us/HT202888
+macPros = [
+            Device(
+            "macProMid2012",
+            "Device is a [Mac Pro (Mid 2012)](https://support.apple.com/kb/SP652)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/macpro_previous.png",
+            ["MacPro5,1"], 0,(), "Mac Pro (Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+]
+## https://support.apple.com/mac/macbook, https://support.apple.com/en-us/HT201608
+macBooks = [
+            Device(
+            "macBookRetina12Inch2017",
+            "Device is a [MacBook (Retina, 12-inch, 2017)](https://support.apple.com/kb/SP757)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2017-device.jpg",
+            ["MacBook10,1"], 0,(), "MacBook (Retina, 12-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookRetina12InchEarly2016",
+            "Device is a [MacBook (Retina, 12-inch, Early 2016)](https://support.apple.com/kb/SP741)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2016-device.jpg",
+            ["MacBook9,1"], 0,(), "MacBook (Retina, 12-inch, Early 2016)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookRetina12InchEarly2015",
+            "Device is a [MacBook (Retina, 12-inch, Early 2015)](https://support.apple.com/kb/SP712)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-2015-device.jpg",
+            ["MacBook8,1"], 0,(), "MacBook (Retina, 12-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBook13InchMid2010",
+            "Device is a [MacBook (13-inch, Mid 2010)](https://support.apple.com/kb/SP584)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
+            ["MacBook7,1"], 0,(), "MacBook (13-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBook13InchLate2009",
+            "Device is a [MacBook (13-inch, Late 2009)](https://support.apple.com/kb/SP579)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
+            ["MacBook6,1"], 0,(), "MacBook (13-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBook13InchMid2009",
+            "Device is a [MacBook (13-inch, Mid 2009)](https://support.apple.com/kb/SP512)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
+            ["MacBook5,2"], 0,(), "MacBook (13-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBook13InchEarly2009",
+            "Device is a [MacBook (13-inch, Early 2009)](https://support.apple.com/kb/SP504)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
+            ["MacBook5,2"], 0,(), "MacBook (13-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+]
+## https://support.apple.com/mac/macbook-air, https://support.apple.com/en-us/HT201862
+macBookAirs = [
+            Device(
+            "macBookAirRetina13Inch2019",
+            "Device is a [MacBook Air (Retina, 13-inch, 2019)](https://support.apple.com/kb/SP798)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2018-device.jpg",
+            ["MacBookAir8,2"], 0,(), "MacBook Air (Retina, 13-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAirRetina13Inch2018",
+            "Device is a [MacBook Air (Retina, 13-inch, 2018)](https://support.apple.com/kb/SP783)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2018-device.jpg",
+            ["MacBookAir8,1"], 0,(), "MacBook Air (Retina, 13-inch, 2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir13Inch2017",
+            "Device is a [MacBook Air (13-inch, 2017)](https://support.apple.com/kb/SP753)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2017-device.jpg",
+            ["MacBookAir7,2"], 0,(), "MacBook Air (13-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir13InchEarly2015",
+            "Device is a [MacBook Air (13-inch, Early 2015)](https://support.apple.com/kb/SP714)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg",
+            ["MacBookAir7,2"], 0,(), "MacBook Air (13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir11InchEarly2015",
+            "Device is a [MacBook Air (11-inch, Early 2015)](https://support.apple.com/kb/SP713)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg",
+            ["MacBookAir7,1"], 0,(), "MacBook Air (11-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir13InchEarly2014",
+            "Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
+            ["MacBookAir6,2"], 0,(), "MacBook Air (13-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir11InchEarly2014",
+            "Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
+            ["MacBookAir6,1"], 0,(), "MacBook Air (11-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir13InchMid2013",
+            "Device is a [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
+            ["MacBookAir6,2"], 0,(), "MacBook Air (13-inch, Mid 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir11InchMid2013",
+            "Device is a [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
+            ["MacBookAir6,1"], 0,(), "MacBook Air (11-inch, Mid 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir13InchMid2012",
+            "Device is a [MacBook Air (13-inch, Mid 2012)](https://support.apple.com/kb/SP670)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg",
+            ["MacBookAir5,2"], 0,(), "MacBook Air (13-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir11InchMid2012",
+            "Device is a [MacBook Air (11-inch, Mid 2012)](https://support.apple.com/kb/SP650)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg",
+            ["MacBookAir5,1"], 0,(), "MacBook Air (11-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir13InchMid2011",
+            "Device is a [MacBook Air (13-inch, Mid 2011)](https://support.apple.com/kb/SP683)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-13in-device.jpg",
+            ["MacBookAir4,2"], 0,(), "MacBook Air (13-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir11InchMid2011",
+            "Device is a [MacBook Air (11-inch, Mid 2011)](https://support.apple.com/kb/SP631)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-13in-device.jpg",
+            ["MacBookAir4,1"], 0,(), "MacBook Air (11-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir13InchLate2010",
+            "Device is a [MacBook Air (13-inch, Late 2010)](https://support.apple.com/kb/SP618)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg",
+            ["MacBookAir3,2"], 0,(), "MacBook Air (13-inch, Late 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAir11InchLate2010",
+            "Device is a [MacBook Air (11-inch, Late 2010)](https://support.apple.com/kb/SP617)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg",
+            ["MacBookAir3,1"], 0,(), "MacBook Air (11-inch, Late 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookAirMid2009",
+            "Device is a [MacBook Air (Mid 2009)](https://support.apple.com/kb/SP548)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg",
+            ["MacBookAir2,1"], 0,(), "MacBook Air (Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+]
+## https://support.apple.com/mac/macbook-pro, https://support.apple.com/en-us/HT201300
+macBookPros = [
+            Device(
+            "macBookPro13Inch2019TwoThunderbolt3Ports",
+            "Device is a [MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP799)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
+            ["MacBookPro15,4"], 0,(), "MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15Inch2019",
+            "Device is a [MacBook Pro (15-inch, 2019)](https://support.apple.com/kb/SP794)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
+            ["MacBookPro15,1,"], 0,(), "MacBook Pro (15-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13Inch2019FourThunderbolt3Ports",
+            "Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
+            ["MacBookPro15,2"], 0,(), "MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15Inch2018",
+            "Device is a [MacBook Pro (15-inch, 2018)](https://support.apple.com/kb/SP776)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg",
+            ["MacBookPro15,1"], 0,(), "MacBook Pro (15-inch, 2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13Inch2018FourThunderbolt3Ports",
+            "Device is a [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg",
+            ["MacBookPro15,2"], 0,(), "MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15Inch2017",
+            "Device is a [MacBook Pro (15-inch, 2017)](https://support.apple.com/kb/SP756)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg",
+            ["MacBookPro14,3"], 0,(), "MacBook Pro (15-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13Inch2017FourThunderbolt3Ports",
+            "Device is a [MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP755)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg",
+            ["MacBookPro14,2"], 0,(), "MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13Inch2017TwoThunderbolt3Ports",
+            "Device is a [MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP754)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg",
+            ["MacBookPro14,1"], 0,(), "MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15Inch2016",
+            "Device is a [MacBook Pro (15-inch, 2016)](https://support.apple.com/kb/SP749)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg",
+            ["MacBookPro13,3"], 0,(), "MacBook Pro (15-inch, 2016)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13Inch2016FourThunderbolt3Ports",
+            "Device is a [MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP748)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg",
+            ["MacBookPro13,2"], 0,(), "MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13Inch2016TwoThunderbolt3Ports",
+            "Device is a [MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP747)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg",
+            ["MacBookPro13,1"], 0,(), "MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina15InchMid2015",
+            "Device is a [MacBook Pro (Retina, 15-inch, Mid 2015)](https://support.apple.com/kb/SP719)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg",
+            ["MacBookPro11,4"], 0,(), "MacBook Pro (Retina, 15-inch, Mid 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina13InchEarly2015",
+            "Device is a [MacBook Pro (Retina, 13-inch, Early 2015)](https://support.apple.com/kb/SP715)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg",
+            ["MacBookPro12,1"], 0,(), "MacBook Pro (Retina, 13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina15InchMid2014",
+            "Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg",
+            ["MacBookPro11,2"], 0,(), "MacBook Pro (Retina, 15-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina13InchMid2014",
+            "Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg",
+            ["MacBookPro11,1"], 0,(), "MacBook Pro (Retina, 13-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina15InchLate2013",
+            "Device is a [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
+            ["MacBookPro11,2"], 0,(), "MacBook Pro (Retina, 15-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina15InchEarly2013",
+            "Device is a [MacBook Pro (Retina, 15-inch, Early 2013)](https://support.apple.com/kb/SP669)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
+            ["MacBookPro10,1"], 0,(), "MacBook Pro (Retina, 15-inch, Early 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina13InchLate2013",
+            "Device is a [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
+            ["MacBookPro11,1"], 0,(), "MacBook Pro (Retina, 13-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina13InchEarly2013",
+            "Device is a [MacBook Pro (Retina, 13-inch, Early 2013)](https://support.apple.com/kb/SP668)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
+            ["MacBookPro10,2"], 0,(), "MacBook Pro (Retina, 13-inch, Early 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina15InchMid2012",
+            "Device is a [MacBook Pro (Retina, 15-inch, Mid 2012)](https://support.apple.com/kb/SP653)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
+            ["MacBookPro10,1"], 0,(), "MacBook Pro (Retina, 15-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15InchMid2012",
+            "Device is a [MacBook Pro (15-inch, Mid 2012)](https://support.apple.com/kb/SP694)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
+            ["MacBookPro9,1"], 0,(), "MacBook Pro (15-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookProRetina13InchLate2012",
+            "Device is a [MacBook Pro (Retina, 13-inch, Late 2012)](https://support.apple.com/kb/SP658)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
+            ["MacBookPro10,2"], 0,(), "MacBook Pro (Retina, 13-inch, Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13InchMid2012",
+            "Device is a [MacBook Pro (13-inch, Mid 2012)](https://support.apple.com/kb/SP649)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
+            ["MacBookPro9,2"], 0,(), "MacBook Pro (13-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro17InchLate2011",
+            "Device is a [MacBook Pro (17-inch, Late 2011)](https://support.apple.com/kb/SP646)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
+            ["MacBookPro8,3"], 0,(), "MacBook Pro (17-inch, Late 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro17InchEarly2011",
+            "Device is a [MacBook Pro (17-inch, Early 2011)](https://support.apple.com/kb/SP621)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
+            ["MacBookPro8,3"], 0,(), "MacBook Pro (17-inch, Early 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15InchLate2011",
+            "Device is a [MacBook Pro (15-inch, Late 2011)](https://support.apple.com/kb/SP644)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
+            ["MacBookPro8,2"], 0,(), "MacBook Pro (15-inch, Late 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15InchEarly2011",
+            "Device is a [MacBook Pro (15-inch, Early 2011)](https://support.apple.com/kb/SP620)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
+            ["MacBookPro8,2"], 0,(), "MacBook Pro (15-inch, Early 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13InchLate2011",
+            "Device is a [MacBook Pro (13-inch, Late 2011)](https://support.apple.com/kb/SP645)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
+            ["MacBookPro8,1"], 0,(), "MacBook Pro (13-inch, Late 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13InchEarly2011",
+            "Device is a [MacBook Pro (13-inch, Early 2011)](https://support.apple.com/kb/SP619)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
+            ["MacBookPro8,1"], 0,(), "MacBook Pro (13-inch, Early 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro17InchMid2010",
+            "Device is a [MacBook Pro (17-inch, Mid 2010)](https://support.apple.com/kb/SP581)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg",
+            ["MacBookPro6,1"], 0,(), "MacBook Pro (17-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15InchMid2010",
+            "Device is a [MacBook Pro (15-inch, Mid 2010)](https://support.apple.com/kb/SP582)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg",
+            ["MacBookPro6,2"], 0,(), "MacBook Pro (15-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13InchMid2010",
+            "Device is a [MacBook Pro (13-inch, Mid 2010)](https://support.apple.com/kb/SP583)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg",
+            ["MacBookPro7,1"], 0,(), "MacBook Pro (13-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro17InchMid2009",
+            "Device is a [MacBook Pro (17-inch, Mid 2009)](https://support.apple.com/kb/SP546)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
+            ["MacBookPro5,2"], 0,(), "MacBook Pro (17-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro17InchEarly2009",
+            "Device is a [MacBook Pro (17-inch, Early 2009)](https://support.apple.com/kb/SP503)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
+            ["MacBookPro5,2"], 0,(), "MacBook Pro (17-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15InchMid2009",
+            "Device is a [MacBook Pro (15-inch, Mid 2009)](https://support.apple.com/kb/SP544)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
+            ["MacBookPro5,3"], 0,(), "MacBook Pro (15-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15Inch253GHzMid2009",
+            "Device is a [MacBook Pro (15-inch, 2.53GHz, Mid 2009)](https://support.apple.com/kb/SP544)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
+            ["MacBookPro5,3"], 0,(), "MacBook Pro (15-inch, 2.53GHz, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro13InchMid2009",
+            "Device is a [MacBook Pro (13-inch, Mid 2009)](https://support.apple.com/kb/SP541)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
+            ["MacBookPro5,5"], 0,(), "MacBook Pro (13-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15InchLate2008",
+            "Device is a [MacBook Pro (15-inch, Late 2008)](https://support.apple.com/kb/SP499)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg",
+            ["MacBookPro5,1"], 0,(), "MacBook Pro (15-inch, Late 2008)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro17InchEarly2008",
+            "Device is a [MacBook Pro (17-inch, Early 2008)](https://support.apple.com/kb/SP4)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg",
+            ["MacBookPro4,1"], 0,(), "MacBook Pro (17-inch, Early 2008)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
+            "macBookPro15InchEarly2008",
+            "Device is a [MacBook Pro (15-inch, Early 2008)](https://support.apple.com/kb/SP4)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg",
+            ["MacBookPro4,1"], 0,(), "MacBook Pro (15-inch, Early 2008)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+]
+## https://support.apple.com/mac/imac-pro
+iMacPros = [
+            Device(
+            "iMacPro",
+            "Device is an [iMac Pro](https://support.apple.com/kb/SP771)",
+            "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP771/SP771-imac-pro-2017.png",
+            ["iMacPro1,1"], 0,(), "iMac Pro (2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+]
 
 iOSDevices = iPods + iPhones + iPads + homePods
 tvOSDevices = tvs
 watchOSDevices = watches
-macOSDevices = macs
+macOSDevices = macMinis + iMacs + macPros + macBooks + macBookAirs + macBookPros + iMacPros
 }%
 #if os(watchOS)
 import WatchKit
@@ -265,6 +754,12 @@ public enum Device {
 
   /// Gets the identifier from the system, such as "iPhone7,1".
   public static var identifier: String = {
+    #if os(macOS)
+    let identifier = try? sysctlData(for: [CTL_HW, HW_MODEL]).withUnsafeBufferPointer { dataPointer -> String? in
+        dataPointer.baseAddress.flatMap { String(validatingUTF8: $0) }
+    }
+    return identifier ?? ""
+    #else
     var systemInfo = utsname()
     uname(&systemInfo)
     let mirror = Mirror(reflecting: systemInfo.machine)
@@ -274,6 +769,7 @@ public enum Device {
       return identifier + String(UnicodeScalar(UInt8(value)))
     }
     return identifier
+    #endif
   }()
 
   /// Maps an identifier to a Device. If the identifier can not be mapped to an existing device, `UnknownDevice(identifier)` is returned.
@@ -307,7 +803,12 @@ public enum Device {
       default: return unknown(identifier)
       }
     #elseif os(macOS)
-    return unknown(identifier)
+      switch identifier {
+    % for device in macOSDevices:
+      case ${', '.join(list(map(lambda device: "\"" + device + "\"", device.identifiers)))}: return ${device.caseName}
+    % end
+      default: return unknown(identifier)
+      }
     #endif
   }
 
@@ -582,6 +1083,67 @@ public enum Device {
     public var hasForceTouchSupport: Bool {
       return isOneOf(Device.allWatchesWithForceTouchSupport)
     }
+  #elseif os(macOS)
+  /// All Macs
+  public static var allMacs: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, macOSDevices)))}]
+  }
+
+  public static var allMacMinis: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, macMinis)))}]
+  }
+
+  public static var allMacBookAirs: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, macBookAirs)))}]
+  }
+
+  public static var allMacBooks: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, macBooks)))}]
+  }
+
+  public static var allMacBookPros: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, macBookPros)))}]
+  }
+
+  public static var allIMacs: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, iMacs)))}]
+  }
+
+  public static var allIMacPros: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, iMacPros)))}]
+  }
+
+  public static var allMacPros: [Device] {
+     return [${', '.join(list(map(lambda device: "." + device.caseName, macPros)))}]
+  }
+
+  public var isMacMini: Bool {
+    return isOneOf(Device.allMacMinis)
+  }
+
+  public var isMacBookAir: Bool {
+    return isOneOf(Device.allMacBookAirs)
+  }
+
+  public var isMacBook: Bool {
+    return isOneOf(Device.allMacBooks)
+  }
+
+  public var isMacBookPro: Bool {
+    return isOneOf(Device.allMacBookPros)
+  }
+
+  public var isIMac: Bool {
+    return isOneOf(Device.allIMacs)
+  }
+
+  public var isIMacPro: Bool {
+    return isOneOf(Device.allIMacPros)
+  }
+
+  public var isMacPro: Bool {
+    return isOneOf(Device.allMacPros)
+  }
   #endif
 
   /// All real devices (i.e. all devices except for all simulators)
@@ -593,7 +1155,7 @@ public enum Device {
     #elseif os(watchOS)
       return allWatches
     #elseif os(macOS)
-      return []
+      return allMacs
     #endif
   }
 
@@ -779,6 +1341,9 @@ extension Device: CustomStringConvertible {
       }
     #elseif os(macOS)
       switch self {
+% for device in macOSDevices:
+      case .${device.caseName}: return "${device.description}"
+% end
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier
       }
@@ -1130,5 +1695,27 @@ extension Device {
     return self.cameras.contains(.ultraWide)
   }
 
+}
+#endif
+
+#if os(macOS)
+private func sysctlData(for keys: [Int32]) throws -> [Int8] {
+    return try keys.withUnsafeBufferPointer { keysPointer -> [Int8] in
+        // Get the data size
+        var requiredSize = 0
+        var result = Darwin.sysctl(UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress), UInt32(keys.count), nil, &requiredSize, nil, 0)
+        if result != 0, let code = POSIXErrorCode(rawValue: errno) {
+            throw POSIXError(code)
+        }
+        // get info
+        let data = [Int8](repeating: 0, count: requiredSize)
+        result = data.withUnsafeBufferPointer { dataBuffer -> Int32 in
+            Darwin.sysctl(UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress), UInt32(keys.count), UnsafeMutableRawPointer(mutating: dataBuffer.baseAddress), &requiredSize, nil, 0)
+        }
+        if result != 0, let code = POSIXErrorCode(rawValue: errno) {
+            throw POSIXError(code)
+        }
+        return data
+    }
 }
 #endif

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -476,7 +476,7 @@ macBookPros = [
 ## https://support.apple.com/mac/imac-pro
 iMacPros = [
             Device(
-            "iMacPro",
+            "iMacPro2017",
             "Device is an [iMac Pro](https://support.apple.com/kb/SP771)",
             "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP771/SP771-imac-pro-2017.png",
             ["iMacPro1,1"], 0,(), "iMac Pro (2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -403,6 +403,11 @@ macBookAirs = [
 ## https://support.apple.com/mac/macbook-pro, https://support.apple.com/en-us/HT201300
 macBookPros = [
             Device(
+            "macBookPro16Inch2019",
+            "Device is a [MacBook Pro (16-inch, 2019)](https://support.apple.com/kb/SP809)",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-16in-2019.jpg",
+            ["MacBookPro16,1"], 0,(), "MacBook Pro (16-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device(
             "macBookPro13Inch2019TwoThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP799)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -171,6 +171,7 @@ watches = [
             ["Watch5,2", "Watch5,4"], 2.0, (4,5), "Apple Watch Series 5 44mm", 326, False, False, False, False, False, False, False, True, False, 0, True, 0)
   ]
 # macOS
+## https://support.apple.com/specs/macmini, https://support.apple.com/en-us/HT201894
 macMinis = [
             Device(
             "macMini2018",
@@ -213,7 +214,7 @@ iMacs = [
             Device(
             "iMacRetina4K215Inch2019",
             "Device is a [iMac (Retina 4K, 21.5-inch, 2019)](https://support.apple.com/kb/SP789)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg",
             ["iMac19,2"], 0,(), "iMac (Retina 4K, 21.5-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina5K27Inch2017",
@@ -223,12 +224,12 @@ iMacs = [
             Device(
             "iMacRetina4K215Inch2017",
             "Device is a [iMac (Retina 4K, 21.5-inch, 2017)](https://support.apple.com/kb/SP759)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg",
             ["iMac18,2"], 0,(), "iMac (Retina 4K, 21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215Inch2017",
             "Device is a [iMac (21.5-inch, 2017)](https://support.apple.com/kb/SP758)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2017.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2017.jpg",
             ["iMac18,1"], 0,(), "iMac (21.5-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina5K27InchLate2015",
@@ -238,12 +239,12 @@ iMacs = [
             Device(
             "iMacRetina4K215InchLate2015",
             "Device is a [iMac (Retina 4K, 21.5-inch, Late 2015)](https://support.apple.com/kb/SP732)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2015.jpg",
             ["iMac16,2"], 0,(), "iMac (Retina 4K, 21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchLate2015",
             "Device is a [iMac (21.5-inch, Late 2015)](https://support.apple.com/kb/SP733)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-21-5-2015.jpg",
             ["iMac16,1"], 0,(), "iMac (21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina5K27InchMid2015",
@@ -352,7 +353,7 @@ macBookAirs = [
             Device(
             "macBookAir11InchEarly2015",
             "Device is a [MacBook Air (11-inch, Early 2015)](https://support.apple.com/kb/SP713)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-13in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2015-11in-device.jpg",
             ["MacBookAir7,1"], 0,(), "MacBook Air (11-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchEarly2014",
@@ -362,7 +363,7 @@ macBookAirs = [
             Device(
             "macBookAir11InchEarly2014",
             "Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699) or [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-11in-device.jpg",
             ["MacBookAir6,1"], 0,(), "MacBook Air (11-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchMid2012",
@@ -372,7 +373,7 @@ macBookAirs = [
             Device(
             "macBookAir11InchMid2012",
             "Device is a [MacBook Air (11-inch, Mid 2012)](https://support.apple.com/kb/SP650)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-13in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2012-11in-device.jpg",
             ["MacBookAir5,1"], 0,(), "MacBook Air (11-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchMid2011",
@@ -382,7 +383,7 @@ macBookAirs = [
             Device(
             "macBookAir11InchMid2011",
             "Device is a [MacBook Air (11-inch, Mid 2011)](https://support.apple.com/kb/SP631)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-13in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2011-11in-device.jpg",
             ["MacBookAir4,1"], 0,(), "MacBook Air (11-inch, Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchLate2010",
@@ -392,7 +393,7 @@ macBookAirs = [
             Device(
             "macBookAir11InchLate2010",
             "Device is a [MacBook Air (11-inch, Late 2010)](https://support.apple.com/kb/SP617)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2009-2010-13in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2010-11in-device.jpg",
             ["MacBookAir3,1"], 0,(), "MacBook Air (11-inch, Late 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAirMid2009",
@@ -415,7 +416,7 @@ macBookPros = [
             Device(
             "macBookPro15Inch2019",
             "Device is a [MacBook Pro (15-inch, 2019)](https://support.apple.com/kb/SP794)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg",
             ["MacBookPro15,3"], 0,(), "MacBook Pro (15-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2019FourThunderbolt3Ports",
@@ -435,12 +436,12 @@ macBookPros = [
             Device(
             "macBookPro13Inch2017FourThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP755)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-13in-device.jpg",
             ["MacBookPro14,2"], 0,(), "MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2017TwoThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP754)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-15in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2017-13in-device-2thunderbolt-3ports.jpg",
             ["MacBookPro14,1"], 0,(), "MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro15Inch2016",
@@ -450,12 +451,12 @@ macBookPros = [
             Device(
             "macBookPro13Inch2016FourThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP748)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-13in-device.jpg",
             ["MacBookPro13,2"], 0,(), "MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2016TwoThunderbolt3Ports",
             "Device is a [MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)](https://support.apple.com/kb/SP747)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-15in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2016-13in-device.jpg",
             ["MacBookPro13,1"], 0,(), "MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina15InchMid2015",
@@ -465,7 +466,7 @@ macBookPros = [
             Device(
             "macBookProRetina13InchEarly2015",
             "Device is a [MacBook Pro (Retina, 13-inch, Early 2015)](https://support.apple.com/kb/SP715)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2015-15in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-2015-13in-device.jpg",
             ["MacBookPro12,1"], 0,(), "MacBook Pro (Retina, 13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina15InchMid2014",
@@ -475,7 +476,7 @@ macBookPros = [
             Device(
             "macBookProRetina13InchMid2014",
             "Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703) or [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg",
+            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-13in-device.jpg",
             ["MacBookPro11,1"], 0,(), "MacBook Pro (Retina, 13-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/imac-pro

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -186,27 +186,22 @@ macMinis = [
             "macMiniLate2012",
             "Device is a [Mac mini (Late 2012)](https://support.apple.com/kb/SP659)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg",
-            ["Macmini6,1" ," Macmini6,2"], 0,(), "Mac mini (Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["Macmini6,1", "Macmini6,2"], 0,(), "Mac mini (Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macMiniMid2011",
             "Device is a [Mac mini (Mid 2011)](https://support.apple.com/kb/SP632)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2011-2012-2014-device.jpg",
-            ["Macmini5,1" ," Macmini5,2"], 0,(), "Mac mini (Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["Macmini5,1", "Macmini5,2"], 0,(), "Mac mini (Mid 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macMiniMid2010",
             "Device is a [Mac mini (Mid 2010)](https://support.apple.com/kb/SP585)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2010-device.jpg",
             ["Macmini4,1"], 0,(), "Mac mini (Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
-            "macMiniLate2009",
-            "Device is a [Mac mini (Late 2009)](https://support.apple.com/kb/SP577)",
+            "macMini2009",
+            "Device is a [Mac mini (Late 2009)](https://support.apple.com/kb/SP577) or [Mac mini (Early 2009)](https://support.apple.com/kb/SP505)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg",
-            ["Macmini3,1"], 0,(), "Mac mini (Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macMiniEarly2009",
-            "Device is a [Mac mini (Early 2009)](https://support.apple.com/kb/SP505)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macmini/mac-mini-2009-device.jpg",
-            ["Macmini3,1"], 0,(), "Mac mini (Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["Macmini3,1"], 0,(), "Mac mini (2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/imac, https://support.apple.com/en-us/HT201634
 iMacs = [
@@ -252,14 +247,9 @@ iMacs = [
             ["iMac16,1"], 0,(), "iMac (21.5-inch, Late 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMacRetina5K27InchMid2015",
-            "Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718)",
+            "Device is a [iMac (Retina 5K, 27-inch, Mid 2015)](https://support.apple.com/kb/SP718) or [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-late-2015.jpg",
-            ["iMac15,1"], 0,(), "iMac (Retina 5K, 27-inch, Mid 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "iMacRetina5K27InchLate2014",
-            "Device is a [iMac (Retina 5K, 27-inch, Late 2014)](https://support.apple.com/kb/SP707)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2014.jpg",
-            ["iMac15,1"], 0,(), "iMac (Retina 5K, 27-inch, Late 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["iMac15,1"], 0,(), "iMac (Retina 5K, 27-inch)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "iMac215InchMid2014",
             "Device is a [iMac (21.5-inch, Mid 2014)](https://support.apple.com/kb/SP701)",
@@ -299,27 +289,7 @@ iMacs = [
             "iMac215InchMid2010",
             "Device is a [iMac (21.5-inch, Mid 2010)](https://support.apple.com/kb/SP588)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2010.jpg",
-            ["iMac11,2"], 0,(), "iMac (21.5-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "iMac27InchLate2009",
-            "Device is a [iMac (27-inch, Late 2009)](https://support.apple.com/kb/SP696)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
-            ["iMac10,1"], 0,(), "iMac (27-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "iMac215InchLate2009",
-            "Device is a [iMac (21.5-inch, Late 2009)](https://support.apple.com/kb/SP576)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
-            ["iMac10,1"], 0,(), "iMac (21.5-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "iMac24InchEarly2009",
-            "Device is a [iMac (24-inch, Early 2009)](https://support.apple.com/kb/SP507)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
-            ["iMac9,1"], 0,(), "iMac (24-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "iMac20InchEarly2009",
-            "Device is a [iMac (20-inch, Early 2009)](https://support.apple.com/kb/SP507)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/imac/imac-27-2009-late.jpg",
-            ["iMac9,1"], 0,(), "iMac (20-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["iMac11,2"], 0,(), "iMac (21.5-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/mac-pro, https://support.apple.com/en-us/HT202888
 macPros = [
@@ -355,17 +325,7 @@ macBooks = [
             "macBook13InchLate2009",
             "Device is a [MacBook (13-inch, Late 2009)](https://support.apple.com/kb/SP579)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
-            ["MacBook6,1"], 0,(), "MacBook (13-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBook13InchMid2009",
-            "Device is a [MacBook (13-inch, Mid 2009)](https://support.apple.com/kb/SP512)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
-            ["MacBook5,2"], 0,(), "MacBook (13-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBook13InchEarly2009",
-            "Device is a [MacBook (13-inch, Early 2009)](https://support.apple.com/kb/SP504)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbook/macbook-late-2009-2010-device.jpg",
-            ["MacBook5,2"], 0,(), "MacBook (13-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["MacBook6,1"], 0,(), "MacBook (13-inch, Late 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/macbook-air, https://support.apple.com/en-us/HT201862
 macBookAirs = [
@@ -383,7 +343,7 @@ macBookAirs = [
             "macBookAir13Inch2017",
             "Device is a [MacBook Air (13-inch, 2017)](https://support.apple.com/kb/SP753)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2017-device.jpg",
-            ["MacBookAir7,2"], 0,(), "MacBook Air (13-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookAir7,3"], 0,(), "MacBook Air (13-inch, 2017)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchEarly2015",
             "Device is a [MacBook Air (13-inch, Early 2015)](https://support.apple.com/kb/SP714)",
@@ -396,24 +356,14 @@ macBookAirs = [
             ["MacBookAir7,1"], 0,(), "MacBook Air (11-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchEarly2014",
-            "Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700)",
+            "Device is a [MacBook Air (13-inch, Early 2014)](https://support.apple.com/kb/SP700) or [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
             ["MacBookAir6,2"], 0,(), "MacBook Air (13-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir11InchEarly2014",
-            "Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699)",
+            "Device is a [MacBook Air (11-inch, Early 2014)](https://support.apple.com/kb/SP699) or [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
             ["MacBookAir6,1"], 0,(), "MacBook Air (11-inch, Early 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookAir13InchMid2013",
-            "Device is a [MacBook Air (13-inch, Mid 2013)](https://support.apple.com/kb/SP678)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
-            ["MacBookAir6,2"], 0,(), "MacBook Air (13-inch, Mid 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookAir11InchMid2013",
-            "Device is a [MacBook Air (11-inch, Mid 2013)](https://support.apple.com/kb/SP677)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookair/macbook-air-2013-2014-13in-device.jpg",
-            ["MacBookAir6,1"], 0,(), "MacBook Air (11-inch, Mid 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookAir13InchMid2012",
             "Device is a [MacBook Air (13-inch, Mid 2012)](https://support.apple.com/kb/SP670)",
@@ -461,10 +411,10 @@ macBookPros = [
             "macBookPro15Inch2019",
             "Device is a [MacBook Pro (15-inch, 2019)](https://support.apple.com/kb/SP794)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
-            ["MacBookPro15,1,"], 0,(), "MacBook Pro (15-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            ["MacBookPro15,3"], 0,(), "MacBook Pro (15-inch, 2019)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro13Inch2019FourThunderbolt3Ports",
-            "Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795)",
+            "Device is a [MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP795) or [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-13in-device.jpg",
             ["MacBookPro15,2"], 0,(), "MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
@@ -472,11 +422,6 @@ macBookPros = [
             "Device is a [MacBook Pro (15-inch, 2018)](https://support.apple.com/kb/SP776)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg",
             ["MacBookPro15,1"], 0,(), "MacBook Pro (15-inch, 2018)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro13Inch2018FourThunderbolt3Ports",
-            "Device is a [MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)](https://support.apple.com/kb/SP775)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-2018-15in-device.jpg",
-            ["MacBookPro15,2"], 0,(), "MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookPro15Inch2017",
             "Device is a [MacBook Pro (15-inch, 2017)](https://support.apple.com/kb/SP756)",
@@ -519,139 +464,14 @@ macBookPros = [
             ["MacBookPro12,1"], 0,(), "MacBook Pro (Retina, 13-inch, Early 2015)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina15InchMid2014",
-            "Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704)",
+            "Device is a [MacBook Pro (Retina, 15-inch, Mid 2014)](https://support.apple.com/kb/SP704) or [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg",
             ["MacBookPro11,2"], 0,(), "MacBook Pro (Retina, 15-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device(
             "macBookProRetina13InchMid2014",
-            "Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703)",
+            "Device is a [MacBook Pro (Retina, 13-inch, Mid 2014)](https://support.apple.com/kb/SP703) or [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)",
             "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2014-15in-device.jpg",
-            ["MacBookPro11,1"], 0,(), "MacBook Pro (Retina, 13-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookProRetina15InchLate2013",
-            "Device is a [MacBook Pro (Retina, 15-inch, Late 2013)](https://support.apple.com/kb/SP690)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
-            ["MacBookPro11,2"], 0,(), "MacBook Pro (Retina, 15-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookProRetina15InchEarly2013",
-            "Device is a [MacBook Pro (Retina, 15-inch, Early 2013)](https://support.apple.com/kb/SP669)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
-            ["MacBookPro10,1"], 0,(), "MacBook Pro (Retina, 15-inch, Early 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookProRetina13InchLate2013",
-            "Device is a [MacBook Pro (Retina, 13-inch, Late 2013)](https://support.apple.com/kb/SP691)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
-            ["MacBookPro11,1"], 0,(), "MacBook Pro (Retina, 13-inch, Late 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookProRetina13InchEarly2013",
-            "Device is a [MacBook Pro (Retina, 13-inch, Early 2013)](https://support.apple.com/kb/SP668)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2013-15in-device.jpg",
-            ["MacBookPro10,2"], 0,(), "MacBook Pro (Retina, 13-inch, Early 2013)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookProRetina15InchMid2012",
-            "Device is a [MacBook Pro (Retina, 15-inch, Mid 2012)](https://support.apple.com/kb/SP653)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
-            ["MacBookPro10,1"], 0,(), "MacBook Pro (Retina, 15-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15InchMid2012",
-            "Device is a [MacBook Pro (15-inch, Mid 2012)](https://support.apple.com/kb/SP694)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
-            ["MacBookPro9,1"], 0,(), "MacBook Pro (15-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookProRetina13InchLate2012",
-            "Device is a [MacBook Pro (Retina, 13-inch, Late 2012)](https://support.apple.com/kb/SP658)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
-            ["MacBookPro10,2"], 0,(), "MacBook Pro (Retina, 13-inch, Late 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro13InchMid2012",
-            "Device is a [MacBook Pro (13-inch, Mid 2012)](https://support.apple.com/kb/SP649)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2012-15in-device.jpg",
-            ["MacBookPro9,2"], 0,(), "MacBook Pro (13-inch, Mid 2012)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro17InchLate2011",
-            "Device is a [MacBook Pro (17-inch, Late 2011)](https://support.apple.com/kb/SP646)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
-            ["MacBookPro8,3"], 0,(), "MacBook Pro (17-inch, Late 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro17InchEarly2011",
-            "Device is a [MacBook Pro (17-inch, Early 2011)](https://support.apple.com/kb/SP621)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
-            ["MacBookPro8,3"], 0,(), "MacBook Pro (17-inch, Early 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15InchLate2011",
-            "Device is a [MacBook Pro (15-inch, Late 2011)](https://support.apple.com/kb/SP644)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
-            ["MacBookPro8,2"], 0,(), "MacBook Pro (15-inch, Late 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15InchEarly2011",
-            "Device is a [MacBook Pro (15-inch, Early 2011)](https://support.apple.com/kb/SP620)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
-            ["MacBookPro8,2"], 0,(), "MacBook Pro (15-inch, Early 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro13InchLate2011",
-            "Device is a [MacBook Pro (13-inch, Late 2011)](https://support.apple.com/kb/SP645)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
-            ["MacBookPro8,1"], 0,(), "MacBook Pro (13-inch, Late 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro13InchEarly2011",
-            "Device is a [MacBook Pro (13-inch, Early 2011)](https://support.apple.com/kb/SP619)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2011-17in-device.jpg",
-            ["MacBookPro8,1"], 0,(), "MacBook Pro (13-inch, Early 2011)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro17InchMid2010",
-            "Device is a [MacBook Pro (17-inch, Mid 2010)](https://support.apple.com/kb/SP581)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg",
-            ["MacBookPro6,1"], 0,(), "MacBook Pro (17-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15InchMid2010",
-            "Device is a [MacBook Pro (15-inch, Mid 2010)](https://support.apple.com/kb/SP582)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg",
-            ["MacBookPro6,2"], 0,(), "MacBook Pro (15-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro13InchMid2010",
-            "Device is a [MacBook Pro (13-inch, Mid 2010)](https://support.apple.com/kb/SP583)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-mid-2010-17in-device.jpg",
-            ["MacBookPro7,1"], 0,(), "MacBook Pro (13-inch, Mid 2010)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro17InchMid2009",
-            "Device is a [MacBook Pro (17-inch, Mid 2009)](https://support.apple.com/kb/SP546)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
-            ["MacBookPro5,2"], 0,(), "MacBook Pro (17-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro17InchEarly2009",
-            "Device is a [MacBook Pro (17-inch, Early 2009)](https://support.apple.com/kb/SP503)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
-            ["MacBookPro5,2"], 0,(), "MacBook Pro (17-inch, Early 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15InchMid2009",
-            "Device is a [MacBook Pro (15-inch, Mid 2009)](https://support.apple.com/kb/SP544)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
-            ["MacBookPro5,3"], 0,(), "MacBook Pro (15-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15Inch253GHzMid2009",
-            "Device is a [MacBook Pro (15-inch, 2.53GHz, Mid 2009)](https://support.apple.com/kb/SP544)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
-            ["MacBookPro5,3"], 0,(), "MacBook Pro (15-inch, 2.53GHz, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro13InchMid2009",
-            "Device is a [MacBook Pro (13-inch, Mid 2009)](https://support.apple.com/kb/SP541)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-early-mid-2009-17in-device.jpg",
-            ["MacBookPro5,5"], 0,(), "MacBook Pro (13-inch, Mid 2009)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15InchLate2008",
-            "Device is a [MacBook Pro (15-inch, Late 2008)](https://support.apple.com/kb/SP499)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg",
-            ["MacBookPro5,1"], 0,(), "MacBook Pro (15-inch, Late 2008)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro17InchEarly2008",
-            "Device is a [MacBook Pro (17-inch, Early 2008)](https://support.apple.com/kb/SP4)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg",
-            ["MacBookPro4,1"], 0,(), "MacBook Pro (17-inch, Early 2008)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device(
-            "macBookPro15InchEarly2008",
-            "Device is a [MacBook Pro (15-inch, Early 2008)](https://support.apple.com/kb/SP4)",
-            "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/macbook-pro-late-2008-15in-device.jpg",
-            ["MacBookPro4,1"], 0,(), "MacBook Pro (15-inch, Early 2008)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
+            ["MacBookPro11,1"], 0,(), "MacBook Pro (Retina, 13-inch, Mid 2014)", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
 ]
 ## https://support.apple.com/mac/imac-pro
 iMacPros = [
@@ -1208,7 +1028,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().name
     #elseif os(macOS)
-    return nil
+    return description
     #else
     return UIDevice.current.name
     #endif
@@ -1220,7 +1040,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
     #elseif os(macOS)
-    return nil
+    return "macOS"
     #else
     return UIDevice.current.systemName
     #endif
@@ -1232,7 +1052,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().systemVersion
     #elseif os(macOS)
-    return nil
+    return ProcessInfo.processInfo.operatingSystemVersionString
     #else
     return UIDevice.current.systemVersion
     #endif
@@ -1244,7 +1064,9 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().model
     #elseif os(macOS)
-    return nil
+    var set = CharacterSet.decimalDigits
+    set.insert(",")
+    return Device.identifier.components(separatedBy: set).joined()
     #else
     return UIDevice.current.model
     #endif
@@ -1256,7 +1078,7 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().localizedModel
     #elseif os(macOS)
-    return nil
+    return model
     #else
     return UIDevice.current.localizedModel
     #endif

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -16,6 +16,11 @@ class DeviceKitTests: XCTestCase {
 
   let device = Device.current
 
+  #if os(macOS)
+  func testDeviceIsKnown() {
+    XCTAssertTrue(device.isOneOf(Device.allMacs))
+  }
+  #else
   func testDeviceSimulator() {
     XCTAssertTrue(device.isOneOf(Device.allSimulators))
   }
@@ -27,6 +32,7 @@ class DeviceKitTests: XCTestCase {
       || device.description.contains("iPod")
       || device.description.contains("TV"))
   }
+  #endif
 
   // MARK: - iOS
   #if os(iOS)


### PR DESCRIPTION
The commit allow to compile with SwiftPM and if necessary I can make a PR just for this one

The second one add models dumped from apple web site

There is some double when using "identifier" so I put the PR as WIP
I do not know what to do. Merge into one. Find a way to make some alias with template generations

My very dirty dump script is available here  https://github.com/phimage/MacModelDump