### PR TITLE
Add support for iPhone 17 series and Apple Watch Ultra 3/Series 11 with version 5.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Version 5.7.0
+
+Releasedate: 2025-09-12
+
+```ruby
+pod 'DeviceKit', '~> 5.7'
+```
+
+### New September 2025 devices
+
+This version adds support for the iPhone 17 series, Apple Watch Ultra 3 and Apple Watch Series 11:
+
+| Device | Case value |
+| --- | --- |
+| iPhone 17 | `Device.iPhone17` |
+| iPhone 17 Pro | `Device.iPhone17Pro` |
+| iPhone 17 Pro Max | `Device.iPhone17ProMax` |
+| iPhone Air | `Device.iPhoneAir` |
+| Apple Watch Ultra 3 | `Device.appleWatchUltra3` |
+| Apple Watch Series 11 42mm | `Device.appleWatchSeries11_42mm` |
+| Apple Watch Series 11 46mm | `Device.appleWatchSeries11_46mm` |
+
+### Bug fixes
+
+- Missing device identifiers for Apple Watch Series 9 were added.
+- Docs for Apple Watch Series 9 was updated to include specs links
+
+Thanks to all the contributers of this release!
+- [Jager-yoo](https://github.com/Jager-yoo)
+
 ## Version 5.6.0
 
 Releasedate: 2025-03-27

--- a/DeviceKit.podspec
+++ b/DeviceKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'DeviceKit'
-  s.version      = '5.6.0'
+  s.version      = '5.7.0'
   s.summary      = 'DeviceKit is a µ-framework that provides a value-type replacement of UIDevice.'
 
   s.description                = <<-DESC

--- a/DeviceKit.xcodeproj/project.pbxproj
+++ b/DeviceKit.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.6.0;
+				MARKETING_VERSION = 5.7.0;
 				MERGEABLE_LIBRARY = YES;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit;
@@ -444,7 +444,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.6.0;
+				MARKETING_VERSION = 5.7.0;
 				MERGEABLE_LIBRARY = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 `DeviceKit` is a value-type replacement of [`UIDevice`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIDevice_Class/).
 
-## Current version 5.6.0
+## Current version 5.7.0
 See our detailed [changelog](CHANGELOG.md) for the latest features, improvements and bug fixes.
 
 ## Features

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -238,6 +238,22 @@ public enum Device {
     ///
     /// ![Image](https://cdsassets.apple.com/live/7WUAS350/images/tech-specs/122208-iphone-16e.png)
     case iPhone16e
+    /// Device is an [iPhone 17]()
+    ///
+    /// ![Image]()
+    case iPhone17
+    /// Device is an [iPhone 17 Pro]()
+    ///
+    /// ![Image]()
+    case iPhone17Pro
+    /// Device is an [iPhone 17 Pro Max]()
+    ///
+    /// ![Image]()
+    case iPhone17ProMax
+    /// Device is an [iPhone Air]()
+    ///
+    /// ![Image]()
+    case iPhoneAir
     /// Device is an [iPad 2](https://support.apple.com/kb/SP622)
     ///
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP622/SP622_01-ipad2-mul.png)
@@ -532,6 +548,18 @@ public enum Device {
     ///
     /// ![Image]()
     case appleWatchSeries10_46mm
+    /// Device is an [Apple Watch Ultra 3]()
+    ///
+    /// ![Image]()
+    case appleWatchUltra3
+    /// Device is an [Apple Watch Series 11]()
+    ///
+    /// ![Image]()
+    case appleWatchSeries11_42mm
+    /// Device is an [Apple Watch Series 11]()
+    ///
+    /// ![Image]()
+    case appleWatchSeries11_46mm
   #endif
 
   /// Device is [Simulator](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/iOS_Simulator_Guide/Introduction/Introduction.html)
@@ -617,6 +645,10 @@ public enum Device {
       case "iPhone17,1": return iPhone16Pro
       case "iPhone17,2": return iPhone16ProMax
       case "iPhone17,5": return iPhone16e
+      case "iPhone18,3": return iPhone17
+      case "iPhone18,1": return iPhone17Pro
+      case "iPhone18,2": return iPhone17ProMax
+      case "iPhone18,4": return iPhoneAir
       case "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4": return iPad2
       case "iPad3,1", "iPad3,2", "iPad3,3": return iPad3
       case "iPad3,4", "iPad3,5", "iPad3,6": return iPad4
@@ -700,6 +732,9 @@ public enum Device {
       case "Watch7,5": return appleWatchUltra2
       case "Watch7,8", "Watch7,10": return appleWatchSeries10_42mm
       case "Watch7,9", "Watch7,11": return appleWatchSeries10_46mm
+      case "Watch7,12": return appleWatchUltra3
+      case "Watch7,17", "Watch7,19": return appleWatchSeries11_42mm
+      case "Watch7,18", "Watch7,20": return appleWatchSeries11_46mm
       case "i386", "x86_64", "arm64": return simulator(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "watchOS"))
       default: return unknown(identifier)
       }
@@ -778,6 +813,10 @@ public enum Device {
         case .iPhone16Pro: return 6.3
         case .iPhone16ProMax: return 6.9
         case .iPhone16e: return 6.1
+        case .iPhone17: return 6.3
+        case .iPhone17Pro: return 6.3
+        case .iPhone17ProMax: return 6.9
+        case .iPhoneAir: return 6.5
         case .iPad2: return 9.7
         case .iPad3: return 9.7
         case .iPad4: return 9.7
@@ -852,6 +891,9 @@ public enum Device {
       case .appleWatchUltra2: return 2.2
       case .appleWatchSeries10_42mm: return 1.9
       case .appleWatchSeries10_46mm: return 2.0
+      case .appleWatchUltra3: return 2.2
+      case .appleWatchSeries11_42mm: return 1.9
+      case .appleWatchSeries11_46mm: return 2.0
       case .simulator(let model): return model.diagonal
       case .unknown: return -1
       }
@@ -910,6 +952,10 @@ public enum Device {
       case .iPhone16Pro: return (width: 9, height: 19.5)
       case .iPhone16ProMax: return (width: 9, height: 19.5)
       case .iPhone16e: return (width: 9, height: 19.5)
+      case .iPhone17: return (width: 9, height: 19.5)
+      case .iPhone17Pro: return (width: 9, height: 19.5)
+      case .iPhone17ProMax: return (width: 9, height: 19.5)
+      case .iPhoneAir: return (width: 9, height: 19.5)
       case .iPad2: return (width: 3, height: 4)
       case .iPad3: return (width: 3, height: 4)
       case .iPad4: return (width: 3, height: 4)
@@ -984,6 +1030,9 @@ public enum Device {
       case .appleWatchUltra2: return (width: 4, height: 5)
       case .appleWatchSeries10_42mm: return (width: 374, height: 446)
       case .appleWatchSeries10_46mm: return (width: 416, height: 496)
+      case .appleWatchUltra3: return (width: 4, height: 5)
+      case .appleWatchSeries11_42mm: return (width: 374, height: 446)
+      case .appleWatchSeries11_46mm: return (width: 416, height: 496)
       case .simulator(let model): return model.screenRatio
       case .unknown: return (width: -1, height: -1)
       }
@@ -1002,7 +1051,7 @@ public enum Device {
 
     /// All iPhones
     public static var allPhones: [Device] {
-      return [.iPhone4, .iPhone4s, .iPhone5, .iPhone5c, .iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e]
+      return [.iPhone4, .iPhone4s, .iPhone5, .iPhone5c, .iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir]
     }
 
     /// All iPads
@@ -1013,17 +1062,17 @@ public enum Device {
     /// All X-Series Devices
     @available(*, deprecated, renamed: "allDevicesWithSensorHousing")
     public static var allXSeriesDevices: [Device] {
-      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e]
+      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir]
     }
 
     /// All Plus and Max-Sized Devices
     public static var allPlusSizedDevices: [Device] {
-      return [.iPhone6Plus, .iPhone6sPlus, .iPhone7Plus, .iPhone8Plus, .iPhoneXSMax, .iPhone11ProMax, .iPhone12ProMax, .iPhone13ProMax, .iPhone14Plus, .iPhone14ProMax, .iPhone15Plus, .iPhone15ProMax, .iPhone16Plus, .iPhone16ProMax]
+      return [.iPhone6Plus, .iPhone6sPlus, .iPhone7Plus, .iPhone8Plus, .iPhoneXSMax, .iPhone11ProMax, .iPhone12ProMax, .iPhone13ProMax, .iPhone14Plus, .iPhone14ProMax, .iPhone15Plus, .iPhone15ProMax, .iPhone16Plus, .iPhone16ProMax, .iPhone17ProMax, .iPhoneAir]
     }
 
     /// All Pro Devices
     public static var allProDevices: [Device] {
-      return [.iPhone11Pro, .iPhone11ProMax, .iPhone12Pro, .iPhone12ProMax, .iPhone13Pro, .iPhone13ProMax, .iPhone14Pro, .iPhone14ProMax, .iPhone15Pro, .iPhone15ProMax, .iPhone16Pro, .iPhone16ProMax, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+      return [.iPhone11Pro, .iPhone11ProMax, .iPhone12Pro, .iPhone12ProMax, .iPhone13Pro, .iPhone13ProMax, .iPhone14Pro, .iPhone14ProMax, .iPhone15Pro, .iPhone15ProMax, .iPhone16Pro, .iPhone16ProMax, .iPhone17Pro, .iPhone17ProMax, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
     }
 
     /// All mini Devices
@@ -1109,12 +1158,12 @@ public enum Device {
 
     /// All Face ID Capable Devices
     public static var allFaceIDCapableDevices: [Device] {
-      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
     }
 
     /// All Devices with Touch ID or Face ID
     public static var allBiometricAuthenticationCapableDevices: [Device] {
-      return [.iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPadAir2, .iPad5, .iPad6, .iPadAir3, .iPad7, .iPad8, .iPad9, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini3, .iPadMini4, .iPadMini5, .iPadMini6, .iPadMiniA17Pro, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+      return [.iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPadAir2, .iPad5, .iPad6, .iPadAir3, .iPad7, .iPad8, .iPad9, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini3, .iPadMini4, .iPadMini5, .iPadMini6, .iPadMiniA17Pro, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
     }
 
     /// Returns whether or not the device has Touch ID
@@ -1134,7 +1183,7 @@ public enum Device {
 
     /// All devices that feature a sensor housing in the screen
     public static var allDevicesWithSensorHousing: [Device] {
-      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e]
+      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir]
     }
 
     /// All simulator devices that feature a sensor housing in the screen
@@ -1149,7 +1198,7 @@ public enum Device {
 
     /// All devices that feature a screen with rounded corners.
     public static var allDevicesWithRoundedDisplayCorners: [Device] {
-      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini6, .iPadMiniA17Pro, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+      return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini6, .iPadMiniA17Pro, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
     }
 
     /// Returns whether or not the device has a screen with rounded corners.
@@ -1159,7 +1208,7 @@ public enum Device {
 
     /// All devices that have the Dynamic Island.
     public static var allDevicesWithDynamicIsland: [Device] {
-      return [.iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax]
+      return [.iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir]
     }
 
     /// Returns whether or not the device has the Dynamic Island.
@@ -1179,7 +1228,7 @@ public enum Device {
 
     /// All devices that support wireless charging.
     public static var allDevicesWithWirelessChargingSupport: [Device] {
-      return [.iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e]
+      return [.iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir]
     }
 
     /// Returns whether or not the device supports wireless charging.
@@ -1189,7 +1238,7 @@ public enum Device {
 
     /// All devices that support 5G.
     public static var allDevicesWith5gSupport: [Device] {
-      return [.iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPad10, .iPadA16, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini6, .iPadMiniA17Pro, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+      return [.iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPad10, .iPadA16, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini6, .iPadMiniA17Pro, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
     }
 
     /// Returns whether or not the device has 5G support.
@@ -1199,7 +1248,7 @@ public enum Device {
 
     /// All devices that have a LiDAR sensor.
     public static var allDevicesWithALidarSensor: [Device] {
-      return [.iPhone12Pro, .iPhone12ProMax, .iPhone13Pro, .iPhone13ProMax, .iPhone14Pro, .iPhone14ProMax, .iPhone15Pro, .iPhone15ProMax, .iPhone16Pro, .iPhone16ProMax, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+      return [.iPhone12Pro, .iPhone12ProMax, .iPhone13Pro, .iPhone13ProMax, .iPhone14Pro, .iPhone14ProMax, .iPhone15Pro, .iPhone15ProMax, .iPhone16Pro, .iPhone16ProMax, .iPhone17Pro, .iPhone17ProMax, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
     }
 
     /// Returns whether or not the device has a LiDAR sensor.
@@ -1209,7 +1258,7 @@ public enum Device {
 
     /// All devices that have a USB-C connectivity.
     public static var allDevicesWithUSBCConnectivity: [Device] {
-      return [.iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini6, .iPadMiniA17Pro, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+      return [.iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini6, .iPadMiniA17Pro, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
     }
 
     /// Returns whether or not the device has a USB-C power supply.
@@ -1229,7 +1278,7 @@ public enum Device {
   #elseif os(watchOS)
     /// All Watches
     public static var allWatches: [Device] {
-       return [.appleWatchSeries0_38mm, .appleWatchSeries0_42mm, .appleWatchSeries1_38mm, .appleWatchSeries1_42mm, .appleWatchSeries2_38mm, .appleWatchSeries2_42mm, .appleWatchSeries3_38mm, .appleWatchSeries3_42mm, .appleWatchSeries4_40mm, .appleWatchSeries4_44mm, .appleWatchSeries5_40mm, .appleWatchSeries5_44mm, .appleWatchSeries6_40mm, .appleWatchSeries6_44mm, .appleWatchSE_40mm, .appleWatchSE_44mm, .appleWatchSeries7_41mm, .appleWatchSeries7_45mm, .appleWatchSeries8_41mm, .appleWatchSeries8_45mm, .appleWatchSE2_40mm, .appleWatchSE2_44mm, .appleWatchUltra, .appleWatchSeries9_41mm, .appleWatchSeries9_45mm, .appleWatchUltra2, .appleWatchSeries10_42mm, .appleWatchSeries10_46mm]
+       return [.appleWatchSeries0_38mm, .appleWatchSeries0_42mm, .appleWatchSeries1_38mm, .appleWatchSeries1_42mm, .appleWatchSeries2_38mm, .appleWatchSeries2_42mm, .appleWatchSeries3_38mm, .appleWatchSeries3_42mm, .appleWatchSeries4_40mm, .appleWatchSeries4_44mm, .appleWatchSeries5_40mm, .appleWatchSeries5_44mm, .appleWatchSeries6_40mm, .appleWatchSeries6_44mm, .appleWatchSE_40mm, .appleWatchSE_44mm, .appleWatchSeries7_41mm, .appleWatchSeries7_45mm, .appleWatchSeries8_41mm, .appleWatchSeries8_45mm, .appleWatchSE2_40mm, .appleWatchSE2_44mm, .appleWatchUltra, .appleWatchSeries9_41mm, .appleWatchSeries9_45mm, .appleWatchUltra2, .appleWatchSeries10_42mm, .appleWatchSeries10_46mm, .appleWatchUltra3, .appleWatchSeries11_42mm, .appleWatchSeries11_46mm]
     }
 
     /// All simulator Watches
@@ -1444,6 +1493,10 @@ public enum Device {
       case .iPhone16Pro: return 460
       case .iPhone16ProMax: return 460
       case .iPhone16e: return 460
+      case .iPhone17: return 460
+      case .iPhone17Pro: return 460
+      case .iPhone17ProMax: return 460
+      case .iPhoneAir: return 460
       case .iPad2: return 132
       case .iPad3: return 264
       case .iPad4: return 264
@@ -1518,6 +1571,9 @@ public enum Device {
     case .appleWatchUltra2: return 338
     case .appleWatchSeries10_42mm: return 326
     case .appleWatchSeries10_46mm: return 326
+    case .appleWatchUltra3: return 338
+    case .appleWatchSeries11_42mm: return 326
+    case .appleWatchSeries11_46mm: return 326
     case .simulator(let model): return model.ppi
     case .unknown: return nil
     }
@@ -1608,6 +1664,10 @@ extension Device: CustomStringConvertible {
       case .iPhone16Pro: return "iPhone 16 Pro"
       case .iPhone16ProMax: return "iPhone 16 Pro Max"
       case .iPhone16e: return "iPhone 16e"
+      case .iPhone17: return "iPhone 17"
+      case .iPhone17Pro: return "iPhone 17 Pro"
+      case .iPhone17ProMax: return "iPhone 17 Pro Max"
+      case .iPhoneAir: return "iPhone Air"
       case .iPad2: return "iPad 2"
       case .iPad3: return "iPad (3rd generation)"
       case .iPad4: return "iPad (4th generation)"
@@ -1682,6 +1742,9 @@ extension Device: CustomStringConvertible {
       case .appleWatchUltra2: return "Apple Watch Ultra2"
       case .appleWatchSeries10_42mm: return "Apple Watch Series 10 42mm"
       case .appleWatchSeries10_46mm: return "Apple Watch Series 10 46mm"
+      case .appleWatchUltra3: return "Apple Watch Ultra 3"
+      case .appleWatchSeries11_42mm: return "Apple Watch Series 11 42mm"
+      case .appleWatchSeries11_46mm: return "Apple Watch Series 11 46mm"
       case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
@@ -1759,6 +1822,10 @@ extension Device: CustomStringConvertible {
       case .iPhone16Pro: return "iPhone 16 Pro"
       case .iPhone16ProMax: return "iPhone 16 Pro Max"
       case .iPhone16e: return "iPhone 16e"
+      case .iPhone17: return "iPhone 17"
+      case .iPhone17Pro: return "iPhone 17 Pro"
+      case .iPhone17ProMax: return "iPhone 17 Pro Max"
+      case .iPhoneAir: return "iPhone Air"
       case .iPad2: return "iPad 2"
       case .iPad3: return "iPad (3rd generation)"
       case .iPad4: return "iPad (4th generation)"
@@ -1833,6 +1900,9 @@ extension Device: CustomStringConvertible {
       case .appleWatchUltra2: return "Apple Watch Ultra2"
       case .appleWatchSeries10_42mm: return "Apple Watch Series 10 42mm"
       case .appleWatchSeries10_46mm: return "Apple Watch Series 10 46mm"
+      case .appleWatchUltra3: return "Apple Watch Ultra 3"
+      case .appleWatchSeries11_42mm: return "Apple Watch Series 11 42mm"
+      case .appleWatchSeries11_46mm: return "Apple Watch Series 11 46mm"
       case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
@@ -2241,6 +2311,8 @@ extension Device {
       case .iPhone15Plus: return [.wide, .ultraWide]
       case .iPhone16: return [.wide, .ultraWide]
       case .iPhone16Plus: return [.wide, .ultraWide]
+      case .iPhone17: return [.wide, .ultraWide]
+      case .iPhoneAir: return [.wide, .ultraWide]
       case .iPadPro11Inch2: return [.wide, .ultraWide]
       case .iPadPro12Inch4: return [.wide, .ultraWide]
       case .iPadPro11Inch3: return [.wide, .ultraWide]
@@ -2259,13 +2331,15 @@ extension Device {
       case .iPhone15ProMax: return [.wide, .telephoto, .ultraWide]
       case .iPhone16Pro: return [.wide, .telephoto, .ultraWide]
       case .iPhone16ProMax: return [.wide, .telephoto, .ultraWide]
+      case .iPhone17Pro: return [.wide, .telephoto, .ultraWide]
+      case .iPhone17ProMax: return [.wide, .telephoto, .ultraWide]
       default: return []
     }
   }
 
   /// All devices that feature a camera
   public static var allDevicesWithCamera: [Device] {
-    return [.iPodTouch5, .iPodTouch6, .iPodTouch7, .iPhone4, .iPhone4s, .iPhone5, .iPhone5c, .iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPad2, .iPad3, .iPad4, .iPadAir, .iPadAir2, .iPad5, .iPad6, .iPadAir3, .iPad7, .iPad8, .iPad9, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini, .iPadMini2, .iPadMini3, .iPadMini4, .iPadMini5, .iPadMini6, .iPadMiniA17Pro, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+    return [.iPodTouch5, .iPodTouch6, .iPodTouch7, .iPhone4, .iPhone4s, .iPhone5, .iPhone5c, .iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPad2, .iPad3, .iPad4, .iPadAir, .iPadAir2, .iPad5, .iPad6, .iPadAir3, .iPad7, .iPad8, .iPad9, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini, .iPadMini2, .iPadMini3, .iPadMini4, .iPadMini5, .iPadMini6, .iPadMiniA17Pro, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
   }
 
   /// All devices that feature a normal camera
@@ -2276,17 +2350,17 @@ extension Device {
 
   /// All devices that feature a wide camera
   public static var allDevicesWithWideCamera: [Device] {
-    return [.iPodTouch5, .iPodTouch6, .iPodTouch7, .iPhone4, .iPhone4s, .iPhone5, .iPhone5c, .iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPad2, .iPad3, .iPad4, .iPadAir, .iPadAir2, .iPad5, .iPad6, .iPadAir3, .iPad7, .iPad8, .iPad9, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini, .iPadMini2, .iPadMini3, .iPadMini4, .iPadMini5, .iPadMini6, .iPadMiniA17Pro, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
+    return [.iPodTouch5, .iPodTouch6, .iPodTouch7, .iPhone4, .iPhone4s, .iPhone5, .iPhone5c, .iPhone5s, .iPhone6, .iPhone6Plus, .iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhoneSE, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhoneSE2, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhoneSE3, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone16e, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPad2, .iPad3, .iPad4, .iPadAir, .iPadAir2, .iPad5, .iPad6, .iPadAir3, .iPad7, .iPad8, .iPad9, .iPad10, .iPadA16, .iPadAir4, .iPadAir5, .iPadAir11M2, .iPadAir13M2, .iPadAir11M3, .iPadAir13M3, .iPadMini, .iPadMini2, .iPadMini3, .iPadMini4, .iPadMini5, .iPadMini6, .iPadMiniA17Pro, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6, .iPadPro11M4, .iPadPro13M4]
   }
 
   /// All devices that feature a telephoto camera
   public static var allDevicesWithTelephotoCamera: [Device] {
-    return [.iPhone7Plus, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhone11Pro, .iPhone11ProMax, .iPhone12Pro, .iPhone12ProMax, .iPhone13Pro, .iPhone13ProMax, .iPhone14Pro, .iPhone14ProMax, .iPhone15Pro, .iPhone15ProMax, .iPhone16Pro, .iPhone16ProMax]
+    return [.iPhone7Plus, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhone11Pro, .iPhone11ProMax, .iPhone12Pro, .iPhone12ProMax, .iPhone13Pro, .iPhone13ProMax, .iPhone14Pro, .iPhone14ProMax, .iPhone15Pro, .iPhone15ProMax, .iPhone16Pro, .iPhone16ProMax, .iPhone17Pro, .iPhone17ProMax]
   }
 
   /// All devices that feature an ultra wide camera
   public static var allDevicesWithUltraWideCamera: [Device] {
-    return [.iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6]
+    return [.iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax, .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax, .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax, .iPhone17, .iPhone17Pro, .iPhone17ProMax, .iPhoneAir, .iPadPro11Inch2, .iPadPro12Inch4, .iPadPro11Inch3, .iPadPro12Inch5, .iPadPro11Inch4, .iPadPro12Inch6]
   }
 
   /// Returns whether or not the current device has a camera
@@ -2379,6 +2453,8 @@ extension Device {
     case a17Pro
     case a18
     case a18Pro
+    case a19
+    case a19Pro
     case m1
     case m2
     case m3
@@ -2450,6 +2526,10 @@ extension Device {
       case .iPhone16Pro: return .a18Pro
       case .iPhone16ProMax: return .a18Pro
       case .iPhone16e: return .a18
+      case .iPhone17: return .a19
+      case .iPhone17Pro: return .a19Pro
+      case .iPhone17ProMax: return .a19Pro
+      case .iPhoneAir: return .a19Pro
       case .iPad2: return .a5
       case .iPad3: return .a5X
       case .iPad4: return .a6X
@@ -2524,6 +2604,9 @@ extension Device {
       case .appleWatchUltra2: return .s9
       case .appleWatchSeries10_42mm: return .s10
       case .appleWatchSeries10_46mm: return .s10
+      case .appleWatchUltra3: return .s10
+      case .appleWatchSeries11_42mm: return .s10
+      case .appleWatchSeries11_46mm: return .s10
       case .simulator(let model): return model.cpu
       case .unknown: return .unknown
     }
@@ -2574,6 +2657,8 @@ extension Device.CPU: CustomStringConvertible {
       case .a17Pro: return "A17 Pro"
       case .a18: return "A18"
       case .a18Pro: return "A18 Pro"
+      case .a19: return "A19"
+      case .a19Pro: return "A19 Pro"
       case .m1: return "M1"
       case .m2: return "M2"
       case .m3: return "M3"

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -91,6 +91,10 @@ iPhones = [
             Device("iPhone16Pro",    "Device is an [iPhone 16 Pro]()",                                                 "",                                                                                                                          ["iPhone17,1"],                               6.3,  (9, 19.5),  "iPhone 16 Pro", "iPhone 16 Pro", 460, False, False, True, True, False, True, True, True, True, True, 0, False, 123, True, "a18Pro", True, True),
             Device("iPhone16ProMax", "Device is an [iPhone 16 Pro Max]()",                                             "",                                                                                                                          ["iPhone17,2"],                               6.9,  (9, 19.5),  "iPhone 16 Pro Max", "iPhone 16 Pro Max", 460, True, False, True, True, False, True, True, True, True, True, 0, False, 123, True, "a18Pro", True, True),
             Device("iPhone16e",      "Device is an [iPhone 16e](https://support.apple.com/en-us/122208)",              "https://cdsassets.apple.com/live/7WUAS350/images/tech-specs/122208-iphone-16e.png",                                         ["iPhone17,5"],                               6.1,  (9, 19.5),  "iPhone 16e", "iPhone 16e", 460, False, False, False, True, False, True, True, True, True, False, 0, False, 1, False, "a18", True, True),
+            Device("iPhone17",       "Device is an [iPhone 17]()",                                                     "",                                                                                                                          ["iPhone18,3"],                               6.3,  (9, 19.5),  "iPhone 17", "iPhone 17", 460, False, False, False, True, False, True, True, True, True, True, 0, False, 13, False, "a19", True, True),
+            Device("iPhone17Pro",    "Device is an [iPhone 17 Pro]()",                                                 "",                                                                                                                          ["iPhone18,1"],                               6.3,  (9, 19.5),  "iPhone 17 Pro", "iPhone 17 Pro", 460, False, False, True, True, False, True, True, True, True, True, 0, False, 123, True, "a19Pro", True, True),
+            Device("iPhone17ProMax", "Device is an [iPhone 17 Pro Max]()",                                             "",                                                                                                                          ["iPhone18,2"],                               6.9,  (9, 19.5),  "iPhone 17 Pro Max", "iPhone 17 Pro Max", 460, True, False, True, True, False, True, True, True, True, True, 0, False, 123, True, "a19Pro", True, True),
+            Device("iPhoneAir",      "Device is an [iPhone Air]()",                                                    "",                                                                                                                          ["iPhone18,4"],                               6.5,  (9, 19.5),  "iPhone Air", "iPhone Air", 460, True, False, False, True, False, True, True, True, True, True, 0, False, 13, False, "a19Pro", True, True),
           ]
 
 iPads = [
@@ -316,6 +320,24 @@ watches = [
             "Device is an [Apple Watch Series 10]()",
             "",
             ["Watch7,9", "Watch7,11"], 2.0, (416,496), "Apple Watch Series 10 46mm", "Apple Watch Series 10 46mm", 326, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s10", False, False),
+
+            Device(
+            "appleWatchUltra3",
+            "Device is an [Apple Watch Ultra 3]()",
+            "",
+            ["Watch7,12"], 2.2, (4,5), "Apple Watch Ultra 3", "Apple Watch Ultra 3", 338, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s10", False, False),
+
+            Device(
+            "appleWatchSeries11_42mm",
+            "Device is an [Apple Watch Series 11]()",
+            "",
+            ["Watch7,17", "Watch7,19"], 1.9, (374,446), "Apple Watch Series 11 42mm", "Apple Watch Series 11 42mm", 326, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s10", False, False),
+
+            Device(
+            "appleWatchSeries11_46mm",
+            "Device is an [Apple Watch Series 11]()",
+            "",
+            ["Watch7,18", "Watch7,20"], 2.0, (416,496), "Apple Watch Series 11 46mm", "Apple Watch Series 11 46mm", 326, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s10", False, False),
 
   ]
 
@@ -1496,6 +1518,8 @@ iOS_cpus = [
           CPU("a17Pro"   , "A17 Pro"),
           CPU("a18"   , "A18"),
           CPU("a18Pro"   , "A18 Pro"),
+          CPU("a19"   , "A19"),
+          CPU("a19Pro"   , "A19 Pro"),
           CPU("m1", "M1"),
           CPU("m2", "M2"),
           CPU("m3", "M3"),

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -459,6 +459,8 @@ class DeviceKitTests: XCTestCase {
       .iPhone15ProMax,
       .iPhone16Plus,
       .iPhone16ProMax,
+      .iPhone17ProMax,
+      .iPhoneAir,
     ])
   }
 
@@ -476,6 +478,8 @@ class DeviceKitTests: XCTestCase {
       .iPhone15ProMax,
       .iPhone16Pro,
       .iPhone16ProMax,
+      .iPhone17Pro,
+      .iPhone17ProMax,
       .iPadPro9Inch,
       .iPadPro12Inch,
       .iPadPro12Inch2,
@@ -521,6 +525,10 @@ class DeviceKitTests: XCTestCase {
       .iPhone16Plus,
       .iPhone16Pro,
       .iPhone16ProMax,
+      .iPhone17,
+      .iPhone17Pro,
+      .iPhone17ProMax,
+      .iPhoneAir,
     ]
     for device in Device.allRealDevices {
       XCTAssertTrue(device.hasDynamicIsland == device.isOneOf(dynamicIslandDevices), "testHasDynamicIsland failed for \(device.description)")
@@ -551,6 +559,10 @@ class DeviceKitTests: XCTestCase {
       .iPhone16Pro,
       .iPhone16ProMax,
       .iPhone16e,
+      .iPhone17,
+      .iPhone17Pro,
+      .iPhone17ProMax,
+      .iPhoneAir,
       .iPad10,
       .iPadA16,
       .iPadAir5,
@@ -644,6 +656,8 @@ class DeviceKitTests: XCTestCase {
       .iPhone15ProMax,
       .iPhone16Pro,
       .iPhone16ProMax,
+      .iPhone17Pro,
+      .iPhone17ProMax,
       .iPadPro11Inch2,
       .iPadPro12Inch4,
       .iPadPro11Inch3,
@@ -669,6 +683,10 @@ class DeviceKitTests: XCTestCase {
       .iPhone16Pro,
       .iPhone16ProMax,
       .iPhone16e,
+      .iPhone17,
+      .iPhone17Pro,
+      .iPhone17ProMax,
+      .iPhoneAir,
       .iPad10,
       .iPadA16,
       .iPadAir4,


### PR DESCRIPTION
…th version 5.7.0 release (#451)

* Initial plan

* Add iPhone 17 series and Apple Watch Ultra 3/Series 11 to Device.swift.gyb template



* Fix Apple Watch Ultra 3 and Series 11 to use S10 chip instead of S11



* Add changelog entry for 5.7.0 and update version numbers

- Add changelog entry for version 5.7.0 with September 12th release date
- Include table of new iPhone 17 series and Apple Watch devices
- Update version to 5.7.0 in README.md, DeviceKit.podspec, and project.pbxproj
- Follow pattern from previous version releases



* Fix changelog.

* Build generated file after copilot gyb implementation.

* Make iPhone Air plus sized.

* More device attribute fixes.

* Update tests after adding new devices.

* Add changelog entry for Series 9 fix.

---------