### PR TITLE
Exclude unhandled files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,12 +33,14 @@ let package = Package(
             name: "DeviceKit",
             dependencies: [],
             path: "Source",
-            resources: [.process("PrivacyInfo.xcprivacy")]
+            exclude: ["Info.plist", "Device.swift.gyb"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
         ),
         .testTarget(
             name: "DeviceKitTests",
             dependencies: ["DeviceKit"],
             path: "Tests",
+            exclude: ["Info.plist"],
             resources: [.process("../Source/PrivacyInfo.xcprivacy")]
         )
     ],


### PR DESCRIPTION
When including DeviceKit as a dependency SPM warns about unhandled files:

warning: 'devicekit': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/kp/Developer/clones/DeviceKit/Tests/Info.plist
warning: 'devicekit': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/kp/Developer/clones/DeviceKit/Source/Device.swift.gyb