### PR TITLE
Update GitHub Actions to macOS 15 with Xcode 26.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -30,7 +30,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    runs-on: macos-14
+    runs-on: macos-15
 
     strategy:
       matrix:
@@ -45,11 +45,11 @@ jobs:
           - platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.2'
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary
- Upgrade test runner from macos-14 to macos-15
- Pin Xcode version to 26.2 (was using latest-stable)
- Update actions/checkout from v2 to v4 (v2 is deprecated and incompatible with newer runners)

All current simulator device names remain available on the updated runners.

🤖 Generated with Claude Code