### PR TITLE
Fix Danger plist warning being triggered on every PR

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -31,9 +31,9 @@ if has_app_changes && !has_test_changes && git.lines_of_code > 10
 end
 
 # Info.plist file shouldn't change often. Leave warning if it changes.
-is_plist_change = git.modified_files.sort == ["ProjectName/Info.plist"].sort
+is_plist_change = git.modified_files.include?("Source/Info.plist")
 
-if !is_plist_change
+if is_plist_change
   warn "Plist changed, don't forget to localize your plist values"
 end
 


### PR DESCRIPTION
## Summary
Fixed the Danger warning "Plist changed, don't forget to localize your plist values" being incorrectly shown on every PR, even when no plist file is modified.

## Changes
- Fixed inverted condition: Changed `if !is_plist_change` to `if is_plist_change` so the warning only fires when a plist is actually modified
- Fixed wrong file path: Changed from checking `"ProjectName/Info.plist"` to `"Source/Info.plist"` to match the actual project structure and work regardless of other modified files

## Test Plan
- PR 487 (which only modifies `.github/workflows/main.yml`) should no longer trigger this warning
- PRs that modify `Source/Info.plist` will correctly show the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)