### PR TITLE
Fix SPM manifest by removing trailing comma

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
             dependencies: [],
             path: "Source",
             exclude: ["Info.plist", "Device.swift.gyb"],
-            resources: [.process("PrivacyInfo.xcprivacy")],
+            resources: [.process("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "DeviceKitTests",


### PR DESCRIPTION
## Summary
Removes trailing comma in Package.swift function arguments that breaks package resolution in Swift 6.0 (Xcode 16.2). SPM fails with "Invalid manifest" error because trailing commas in function argument lists are not supported until Swift 6.1.

## Test plan
- Verify package can be resolved in Xcode 16.2
- Confirm no syntax errors in Package.swift manifest