### PR TITLE
Upgrade GitHub Actions to macOS 26 with arm64 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,10 @@ jobs:
           - platform=iOS Simulator,name=iPhone 17
           - platform=iOS Simulator,name=iPhone Air
           - platform=iOS Simulator,name=iPhone 16e
+          - platform=iOS Simulator,name=iPad (A16)
+          - platform=iOS Simulator,name=iPad Air 13-inch (M3)
+          - platform=iOS Simulator,name=iPad mini (A17 Pro)
+          - platform=iOS Simulator,name=iPad Pro 13-inch (M5)
           - platform=tvOS Simulator,name=Apple TV
           - platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
           - platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,19 +30,19 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    runs-on: macos-15
+    runs-on: macos-26
 
     strategy:
       matrix:
         platform:
-          - platform=iOS Simulator,name=iPhone 16 Pro Max
-          - platform=iOS Simulator,name=iPhone 16 Pro
-          - platform=iOS Simulator,name=iPhone 16
-          - platform=iOS Simulator,name=iPhone 16 Plus
-          - platform=iOS Simulator,name=iPhone SE (3rd generation)
+          - platform=iOS Simulator,name=iPhone 17 Pro Max
+          - platform=iOS Simulator,name=iPhone 17 Pro
+          - platform=iOS Simulator,name=iPhone 17
+          - platform=iOS Simulator,name=iPhone Air
+          - platform=iOS Simulator,name=iPhone 16e
           - platform=tvOS Simulator,name=Apple TV
           - platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
-          - platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)
+          - platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Updates CI runner from macos-15 to macos-26 (arm64)
- Adjusts simulator devices to match macOS 26 availability
- Updates to newer device models: iPhone 17 series, Apple Watch Series 11

## Test plan
- CI workflow will execute on macOS 26 arm64 runners
- Tests will run on all specified simulator devices
- Verify all iOS, tvOS, and watchOS platforms pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)